### PR TITLE
fix(list_playbooks): name filter + per-call limit (max 500)

### DIFF
--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -391,6 +391,10 @@ TOOL_SCHEMAS: dict[str, dict] = {
         "inputSchema": {
             "type": "object",
             "properties": {
+                "name_contains": {
+                    "type": "string",
+                    "description": "Optional case-insensitive filter on the playbook name (substring).",
+                },
                 "category": {
                     "type": "string",
                     "description": "Optional filter by playbook category.",
@@ -399,6 +403,10 @@ TOOL_SCHEMAS: dict[str, dict] = {
                     "type": "boolean",
                     "description": "Return only active playbooks (default: true).",
                     "default": True,
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of playbooks to return (default: server max_results, max: 500).",
                 },
             },
         },
@@ -1274,12 +1282,16 @@ def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: di
     """List available SOAR playbooks."""
     active_only = args.get("active_only", True)
     category = args.get("category", "")
+    name_contains = args.get("name_contains", "")
+    limit = max(1, min(int(args.get("limit") or config.max_results), 500))
 
-    params: dict = {"page_size": config.max_results}
+    params: dict = {"page_size": limit}
     if active_only:
         params["_filter_active"] = "true"  # SOAR requires lowercase (bug #7)
     if category:
         params["_filter_category__icontains"] = f'"{category}"'
+    if name_contains:
+        params["_filter_name__icontains"] = f'"{name_contains}"'
 
     data, err = client.get("playbook", params=params)
     if err:


### PR DESCRIPTION
## Change-Contract
- **Datei:** `soar_mcp_tools.py` — `list_playbooks` inputSchema + `tool_list_playbooks`
- **Was ändert sich:** zwei neue optionale Parameter
  - `name_contains` (string) → SOAR-Filter `_filter_name__icontains`
  - `limit` (int, default = `config.max_results`, geklemmt auf `[1, 500]`) → `page_size`
- **Was bleibt unangetastet:** `category`/`active_only`-Logik, globaler `config.max_results`, alle übrigen Tools

## Motivation
Bei 415 Playbooks lieferte `list_playbooks` nur `max_results` (default 50) ohne Namenssuche — ein bestimmtes (z. B. frisch importiertes) Playbook war so nicht auffindbar.

## Verifikation
- `py_compile` OK; bestehende Suite `test_soar_mcp_tokens.py` unverändert grün (20 Tests, OK)
- Offline-Param-Test (Fake-Client): `name_contains` → korrekter Filter; `limit=9999` → auf 500 geklemmt; `limit=200` → 200; ohne `name_contains` kein Filter

⚠️ Wirkt live erst nach **Redeploy + MCP-Reconnect** (Tool-Schema wird beim Connect gecached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)