### PR TITLE
Fix SOAR 8.5 playbook listing filters

### DIFF
--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -1273,13 +1273,9 @@ def tool_list_case_notes(client: SoarApiClient, config: McpServerConfig, args: d
 def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: dict) -> str:
     """List available SOAR playbooks."""
     active_only = args.get("active_only", True)
-    category = args.get("category", "")
+    category = (args.get("category", "") or "").strip()
 
     params: dict = {"page_size": config.max_results}
-    if active_only:
-        params["_filter_active"] = "true"  # SOAR requires lowercase (bug #7)
-    if category:
-        params["_filter_category__icontains"] = f'"{category}"'
 
     data, err = client.get("playbook", params=params)
     if err:
@@ -1287,6 +1283,11 @@ def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: di
 
     items = data if isinstance(data, list) else data.get("data", [])
     total = data.get("count", len(items)) if isinstance(data, dict) else len(items)
+    if active_only:
+        items = [pb for pb in items if bool(pb.get("active"))]
+    if category:
+        cat = category.lower()
+        items = [pb for pb in items if cat in str(pb.get("category", "")).lower()]
     if not items:
         return "No playbooks found."
 

--- a/test_soar_mcp_soar85_list_playbooks.py
+++ b/test_soar_mcp_soar85_list_playbooks.py
@@ -1,0 +1,41 @@
+"""Regression coverage for SOAR 8.5 playbook listing behavior."""
+from __future__ import annotations
+
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import tool_list_playbooks
+
+
+class _FakePlaybookClient:
+    def __init__(self) -> None:
+        self.get_calls: list[tuple[str, dict | None]] = []
+
+    def get(self, path, params=None):
+        self.get_calls.append((path, params))
+        if path == "playbook":
+            return {
+                "data": [
+                    {"id": 1, "name": "Active PB", "active": True, "category": "response"},
+                    {"id": 2, "name": "Inactive PB", "active": False, "category": "response"},
+                ],
+                "count": 2,
+            }, None
+        return {}, None
+
+
+class Soar85ListPlaybooksTest(unittest.TestCase):
+    def test_list_playbooks_filters_active_locally(self):
+        cfg = McpServerConfig()
+        cfg.advisory_disclaimer = False
+        client = _FakePlaybookClient()
+
+        out = tool_list_playbooks(client, cfg, {"active_only": True})
+
+        self.assertIn("Active PB", out)
+        self.assertNotIn("Inactive PB", out)
+        self.assertEqual(client.get_calls[0], ("playbook", {"page_size": 50}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Fix SOAR 8.5 playbook listing filters

## Summary
- Avoid sending active/category filters that are unreliable on SOAR 8.5.
- Fetch the playbook page and apply `active_only` and `category` filters locally.
- Preserve the existing user-facing output format.

## Why
On the tested SOAR 8.5 instance, `/rest/playbook` rejects or mishandles the active
filter used by `list_playbooks`, which makes the MCP tool fail before returning
otherwise valid playbook records.

## Validation
```bash
python3 -m py_compile soar_mcp_tools.py
python3 -m unittest test_soar_mcp_soar85_list_playbooks -v
```

## Local branch
`upstream/pr1-soar85-list-playbooks`

## Stack note
This is part of a five-PR SOAR 8.5 compatibility series.
Preferred focused review base: `main`.
GitHub upstream PRs target `main` because this account does not have permission to create intermediate base branches in `abuis78/soar_mcp_server`.
