### PR TITLE
Normalize SOAR 8.5 COA summaries and current draft handling

### DIFF
--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -2042,29 +2042,50 @@ def _resolve_current_id(
         or coa_data.get("id")
         or pid
     )
-    return int(raw_current), coa_data, None
+    current_id = int(raw_current)
+
+    # SOAR 8.5 can return current_id while still returning the old revision's
+    # graph for /coa/playbooks/<old_id>. Refetch the current draft payload before
+    # any COA graph analysis so stale URLs do not poison downstream checks.
+    if current_id != pid:
+        current_data, current_err = client._coa_get(f"playbooks/{current_id}")
+        if not current_err and isinstance(current_data, dict):
+            return current_id, current_data, None
+
+    return current_id, coa_data, None
 
 
 def _get_coa_nodes_edges(coa_data: dict) -> tuple[list, list]:
     """
     Extract nodes and edges from a COA graph response.
 
-    Known shapes (issue #30 — second fix):
+    Known shapes:
       A) export archive JSON:   coa_data["coa"]["data"]["nodes"]
       B) live /coa/playbooks/{id} on SOAR 8.5 (no outer "coa" wrapper):
                                 coa_data["data"]["nodes"]
       C) flat top-level:        coa_data["nodes"]
+      D) older SOAR 8.5 hotfix shape:
+                                coa_data["coa_data"]["nodes"]
 
     Nodes may be a dict keyed by string node-id — normalised to list.
     Edges field may be "connections" or "edges".
     """
     coa_sub = coa_data.get("coa") or {}
+    coa_data_sub = coa_data.get("coa_data") or {}
+    if isinstance(coa_data_sub, str):
+        try:
+            coa_data_sub = json.loads(coa_data_sub)
+        except Exception:
+            coa_data_sub = {}
+    if not isinstance(coa_data_sub, dict):
+        coa_data_sub = {}
 
-    # data_sub: prefer shape A (coa.data), then shape B (data at top level)
-    data_sub = coa_sub.get("data") or coa_data.get("data") or {}
+    # data_sub: prefer shape A (coa.data), then B (top-level data), then D.
+    data_sub = coa_sub.get("data") or coa_data.get("data") or coa_data_sub or {}
 
     nodes_raw = (
         data_sub.get("nodes")        # shapes A and B
+        or coa_data_sub.get("nodes") # shape D
         or coa_sub.get("nodes")      # coa.nodes (uncommon fallback)
         or coa_data.get("nodes")     # shape C
         or {}
@@ -2078,13 +2099,61 @@ def _get_coa_nodes_edges(coa_data: dict) -> tuple[list, list]:
 
     edges_raw = (
         data_sub.get("connections") or data_sub.get("edges")
+        or coa_data_sub.get("connections") or coa_data_sub.get("edges")
         or coa_sub.get("connections") or coa_sub.get("edges")
         or coa_data.get("connections") or coa_data.get("edges")
         or coa_data.get("links")
         or []
     )
     edges: list = edges_raw if isinstance(edges_raw, list) else []
-    return nodes, edges
+
+    def _issue_list(value: Any) -> list:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [v for v in value.values() if v]
+        return []
+
+    normalized_nodes: list[dict] = []
+    node_name_by_id: dict[str, str] = {}
+    for raw in nodes:
+        if not isinstance(raw, dict):
+            continue
+        data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
+        rec = dict(data) if data else dict(raw)
+
+        node_id = raw.get("id", rec.get("id"))
+        if node_id is not None:
+            rec["id"] = node_id
+            rec["node_id"] = node_id
+        rec["x"] = raw.get("x", rec.get("x", 0))
+        rec["y"] = raw.get("y", rec.get("y", 0))
+        rec["warnings"] = _issue_list(raw.get("warnings", rec.get("warnings", [])))
+        rec["errors"] = _issue_list(raw.get("errors", rec.get("errors", [])))
+        if "userCode" in raw and "userCode" not in rec:
+            rec["userCode"] = raw.get("userCode")
+
+        fn_name = rec.get("functionName") or rec.get("function_name") or rec.get("name") or ""
+        if node_id is not None:
+            node_name_by_id[str(node_id)] = str(fn_name)
+        normalized_nodes.append(rec)
+
+    normalized_edges: list[dict] = []
+    for raw in edges:
+        if not isinstance(raw, dict):
+            continue
+        rec = dict(raw)
+        src_id = rec.get("source") or rec.get("source_id") or rec.get("from") or rec.get("sourceNode")
+        tgt_id = rec.get("target") or rec.get("target_id") or rec.get("to") or rec.get("targetNode")
+        if src_id is not None:
+            rec["source"] = src_id
+            rec.setdefault("source_function", node_name_by_id.get(str(src_id), str(src_id)))
+        if tgt_id is not None:
+            rec["target"] = tgt_id
+            rec.setdefault("target_function", node_name_by_id.get(str(tgt_id), str(tgt_id)))
+        normalized_edges.append(rec)
+
+    return normalized_nodes, normalized_edges
 
 
 def _coa_shape_debug(coa_data: dict) -> dict:
@@ -2465,7 +2534,13 @@ def tool_get_playbook_coa_summary(
     passed_validation = rest_data.get("passed_validation", coa_data.get("passed_validation", False))
     # VERIFY: playbook_type / trigger field names
     playbook_type = rest_data.get("playbook_type") or coa_data.get("playbook_type", "")
-    trigger = rest_data.get("trigger") or coa_data.get("trigger", "")
+    trigger = (
+        rest_data.get("playbook_trigger")
+        or rest_data.get("trigger")
+        or coa_data.get("playbook_trigger")
+        or coa_data.get("trigger")
+        or ""
+    )
 
     findings = []
     if warning_count:

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -1273,13 +1273,9 @@ def tool_list_case_notes(client: SoarApiClient, config: McpServerConfig, args: d
 def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: dict) -> str:
     """List available SOAR playbooks."""
     active_only = args.get("active_only", True)
-    category = args.get("category", "")
+    category = (args.get("category", "") or "").strip()
 
     params: dict = {"page_size": config.max_results}
-    if active_only:
-        params["_filter_active"] = "true"  # SOAR requires lowercase (bug #7)
-    if category:
-        params["_filter_category__icontains"] = f'"{category}"'
 
     data, err = client.get("playbook", params=params)
     if err:
@@ -1287,6 +1283,11 @@ def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: di
 
     items = data if isinstance(data, list) else data.get("data", [])
     total = data.get("count", len(items)) if isinstance(data, dict) else len(items)
+    if active_only:
+        items = [pb for pb in items if bool(pb.get("active"))]
+    if category:
+        cat = category.lower()
+        items = [pb for pb in items if cat in str(pb.get("category", "")).lower()]
     if not items:
         return "No playbooks found."
 

--- a/test_soar_mcp_soar85_coa_summary.py
+++ b/test_soar_mcp_soar85_coa_summary.py
@@ -1,0 +1,94 @@
+"""Regression coverage for SOAR 8.5 COA graph and summary behavior."""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import (
+    _get_coa_nodes_edges,
+    _resolve_current_id,
+    tool_get_playbook_coa_summary,
+)
+
+
+class _FakeCoaClient:
+    def __init__(self) -> None:
+        self.coa = {
+            "id": 180,
+            "current_id": 180,
+            "playbook_trigger": "artifact_created",
+            "coa_data": {
+                "nodes": {
+                    "0": {
+                        "id": "0",
+                        "x": 10,
+                        "y": 20,
+                        "data": {"type": "code", "functionName": "do_work"},
+                    }
+                },
+                "edges": [],
+            },
+        }
+
+    def get(self, path, params=None):
+        if path == "playbook/180":
+            return {
+                "id": 180,
+                "name": "Quarantine",
+                "version": 9,
+                "playbook_trigger": "artifact_created",
+                "passed_validation": True,
+            }, None
+        return {}, None
+
+    def _coa_get(self, path, params=None):
+        return self.coa, None
+
+    def get_binary(self, path, params=None):
+        return b"", None
+
+
+class _StaleCoaClient:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def _coa_get(self, path, params=None):
+        self.calls.append(path)
+        if path == "playbooks/172":
+            return {"id": 172, "current_id": 180, "coa_data": {"nodes": {"old": {}}}}, None
+        if path == "playbooks/180":
+            return {"id": 180, "current_id": 180, "coa_data": {"nodes": {"current": {}}}}, None
+        return {}, None
+
+
+class Soar85CoaSummaryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = McpServerConfig()
+        self.cfg.advisory_disclaimer = False
+
+    def test_coa_data_shape_is_normalized(self):
+        client = _FakeCoaClient()
+        nodes, edges = _get_coa_nodes_edges(client.coa)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(len(edges), 0)
+        self.assertEqual(nodes[0]["functionName"], "do_work")
+        self.assertEqual(nodes[0]["x"], 10)
+
+    def test_resolve_current_id_refetches_current_payload(self):
+        client = _StaleCoaClient()
+        current_id, coa_data, err = _resolve_current_id(client, 172)
+        self.assertIsNone(err)
+        self.assertEqual(current_id, 180)
+        self.assertEqual(coa_data["id"], 180)
+        self.assertEqual(client.calls, ["playbooks/172", "playbooks/180"])
+
+    def test_coa_summary_reads_playbook_trigger(self):
+        client = _FakeCoaClient()
+        data = json.loads(tool_get_playbook_coa_summary(client, self.cfg, {"playbook_id": 180}))
+        self.assertEqual(data["data"]["trigger"], "artifact_created")
+        self.assertEqual(data["data"]["node_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_soar85_list_playbooks.py
+++ b/test_soar_mcp_soar85_list_playbooks.py
@@ -1,0 +1,41 @@
+"""Regression coverage for SOAR 8.5 playbook listing behavior."""
+from __future__ import annotations
+
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import tool_list_playbooks
+
+
+class _FakePlaybookClient:
+    def __init__(self) -> None:
+        self.get_calls: list[tuple[str, dict | None]] = []
+
+    def get(self, path, params=None):
+        self.get_calls.append((path, params))
+        if path == "playbook":
+            return {
+                "data": [
+                    {"id": 1, "name": "Active PB", "active": True, "category": "response"},
+                    {"id": 2, "name": "Inactive PB", "active": False, "category": "response"},
+                ],
+                "count": 2,
+            }, None
+        return {}, None
+
+
+class Soar85ListPlaybooksTest(unittest.TestCase):
+    def test_list_playbooks_filters_active_locally(self):
+        cfg = McpServerConfig()
+        cfg.advisory_disclaimer = False
+        client = _FakePlaybookClient()
+
+        out = tool_list_playbooks(client, cfg, {"active_only": True})
+
+        self.assertIn("Active PB", out)
+        self.assertNotIn("Inactive PB", out)
+        self.assertEqual(client.get_calls[0], ("playbook", {"page_size": 50}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Normalize SOAR 8.5 COA summaries and current draft handling

## Summary
- Refetch `/coa/playbooks/{current_id}` when SOAR returns a stale input ID with a
  newer current draft ID.
- Normalize `coa_data.nodes` / `coa_data.edges` alongside existing COA graph
  shapes.
- Preserve node position, warning/error and function metadata when normalizing
  graph nodes.
- Read `playbook_trigger` as a fallback for COA summaries.

## Why
SOAR 8.5 can return `current_id` while still returning the older revision graph
for the originally requested playbook ID. It can also expose graph content under
`coa_data`, and trigger metadata under `playbook_trigger`.

## Validation
```bash
python3 -m py_compile soar_mcp_tools.py
python3 -m unittest test_soar_mcp_soar85_coa_summary -v
```

## Local branch
`upstream/pr2-soar85-coa-current-summary`

## Stack note
This is part of a five-PR SOAR 8.5 compatibility series.
Preferred focused review base: `upstream/pr1-soar85-list-playbooks`.
GitHub upstream PRs target `main` because this account does not have permission to create intermediate base branches in `abuis78/soar_mcp_server`.
