### PR TITLE
Use SOAR 8.5 Python payloads for validation and drift checks

### DIFF
--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import textwrap
 from typing import Any, Optional
 
 import requests
@@ -2232,6 +2233,28 @@ def _get_graph(
     return nodes, edges
 
 
+def _extract_python_from_export(client: "SoarApiClient", playbook_id: int) -> Optional[str]:
+    """Return the generated .py payload from a playbook export archive."""
+    import io as _io_py
+    import tarfile as _tarfile_py
+
+    content, _ = client.get_binary(f"playbook/{playbook_id}/export")
+    if not content:
+        return None
+    try:
+        buf = _io_py.BytesIO(content)
+        with _tarfile_py.open(fileobj=buf, mode="r:*") as tarf:
+            for member in tarf.getmembers():
+                if not member.name.endswith(".py"):
+                    continue
+                fobj = tarf.extractfile(member)
+                if fobj:
+                    return fobj.read().decode("utf-8", errors="replace")
+    except Exception:
+        return None
+    return None
+
+
 def _extract_python_from_coa(nodes: list) -> Optional[str]:
     """
     Reconstruct a Python payload from COA userCode blocks.
@@ -2251,8 +2274,88 @@ def _extract_python_from_coa(nodes: list) -> Optional[str]:
             fn_name = (
                 n.get("functionName") or n.get("function_name") or n.get("name") or "block"
             )
-            parts.append(f"# --- {fn_name} ---\n{code}")
+            parts.append(f"# --- {fn_name} ---\n{textwrap.dedent(str(code)).strip()}")
     return "\n\n".join(parts) if parts else None
+
+
+def _extract_python_from_coa_payload(coa_data: dict) -> Optional[str]:
+    """Return full generated Python from known COA envelope fields, if present."""
+    candidates: list[Any] = [
+        coa_data.get("python"),
+        coa_data.get("code"),
+        (coa_data.get("coa") or {}).get("python") if isinstance(coa_data.get("coa"), dict) else None,
+        (coa_data.get("coa") or {}).get("code") if isinstance(coa_data.get("coa"), dict) else None,
+    ]
+    data_sub = (coa_data.get("coa") or {}).get("data") if isinstance(coa_data.get("coa"), dict) else None
+    if not data_sub and isinstance(coa_data.get("data"), dict):
+        data_sub = coa_data.get("data")
+    if isinstance(data_sub, dict):
+        candidates.extend([data_sub.get("python"), data_sub.get("code")])
+    for value in candidates:
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _select_playbook_python(
+    client: "SoarApiClient",
+    current_id: int,
+    coa_data: dict,
+    rest_data: dict | None,
+    nodes: list,
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Return the best full Python payload for validation/drift checks.
+
+    Prefer full generated sources (REST/COA/export) over node snippets. Node
+    snippets are a last resort because SOAR may store them indented relative to
+    generated wrapper code, which can false-fail py_compile.
+    """
+    if isinstance(rest_data, dict):
+        for key in ("code", "script", "playbook_run_data", "python"):
+            value = rest_data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value, f"rest_{key}"
+
+    coa_python = _extract_python_from_coa_payload(coa_data)
+    if coa_python:
+        return coa_python, "coa_python"
+
+    export_python = _extract_python_from_export(client, current_id)
+    if export_python:
+        return export_python, "export_archive"
+
+    snippet_python = _extract_python_from_coa(nodes)
+    if snippet_python:
+        return snippet_python, "coa_usercode_snippets"
+
+    return None, None
+
+
+def _collect_coa_owned_function_names(nodes: list) -> set[str]:
+    """Collect generated function names that are owned by the COA graph."""
+    import ast as _ast_owned
+
+    names: set[str] = {"on_start", "on_finish"}
+    for n in nodes:
+        if not isinstance(n, dict):
+            continue
+        fn_name = n.get("functionName") or n.get("function_name") or n.get("name")
+        if fn_name:
+            fn = str(fn_name)
+            names.add(fn)
+            names.add(f"{fn}_callback")
+        code = n.get("userCode") or n.get("user_code") or n.get("code") or ""
+        if code:
+            try:
+                tree = _ast_owned.parse(textwrap.dedent(str(code)))
+                for node_obj in _ast_owned.walk(tree):
+                    if isinstance(node_obj, _ast_owned.FunctionDef):
+                        names.add(node_obj.name)
+                        names.add(f"{node_obj.name}_callback")
+            except SyntaxError:
+                pass
+    return names
 
 
 def _normalize_coa_volatile(data: object, _depth: int = 0) -> object:
@@ -2755,40 +2858,23 @@ def tool_check_saved_generated_python_drift(
         errors.append({"source": "coa", "message": err})
 
     nodes, _ = _get_graph(client, current_id, coa_data)
+    coa_functions = _collect_coa_owned_function_names(nodes)
 
-    # Collect COA userCode blocks from code-type nodes
-    # VERIFY: field name "userCode" inside a code node — may be "user_code" or "code"
-    coa_functions: set[str] = set()
-    for n in nodes:
-        if (n.get("type") or "").lower() == "code":
-            user_code = n.get("userCode") or n.get("user_code") or n.get("code") or ""
-            if user_code:
-                try:
-                    tree = _ast.parse(user_code)
-                    for node_obj in _ast.walk(tree):
-                        if isinstance(node_obj, _ast.FunctionDef):
-                            coa_functions.add(node_obj.name)
-                except SyntaxError:
-                    pass
-
-    # Fetch saved Python payload from REST
-    # VERIFY: field name for saved Python in /rest/playbook/{id} — may be "code", "script", or "playbook_run_data"
     rest_data, rest_err = client.get(f"playbook/{current_id}")
-    saved_python: Optional[str] = None
-    python_payload_available = False
-    if isinstance(rest_data, dict):
-        saved_python = (
-            rest_data.get("code")
-            or rest_data.get("script")
-            or rest_data.get("playbook_run_data")
-        )
-        if saved_python:
-            python_payload_available = True
+    if rest_err:
+        errors.append({"source": "rest", "message": rest_err})
+    saved_python, python_source = _select_playbook_python(
+        client,
+        current_id,
+        coa_data,
+        rest_data if isinstance(rest_data, dict) else {},
+        nodes,
+    )
 
-    if not python_payload_available:
+    if not saved_python:
         result = {
-            "ok": True,
-            "summary": "Python payload not available in REST response — check skipped.",
+            "ok": False,
+            "summary": "Python payload not available from REST, COA, or export archive — check skipped.",
             "data": {
                 "current_id": current_id,
                 "drift_detected": False,
@@ -2799,9 +2885,13 @@ def tool_check_saved_generated_python_drift(
                 "saved_python_functions": [],
                 "external_helper_candidates": [],
                 "status": "skipped",
-                "skip_reason": "saved Python payload not found in /rest/playbook response — VERIFY field name",  # noqa
+                "skip_reason": "saved Python payload not found in REST, COA, or export archive",
             },
-            "findings": [],
+            "findings": [{
+                "severity": "warn",
+                "code": "python_payload_unavailable",
+                "message": "Could not inspect generated Python; drift status is unknown.",
+            }],
             "errors": errors,
         }
         return json.dumps(result, indent=2)
@@ -2825,6 +2915,7 @@ def tool_check_saved_generated_python_drift(
                 "drift_detected": False,
                 "method": "fallback_unavailable",
                 "python_payload_available": True,
+                "python_source": python_source,
                 "ast_parse_succeeded": False,
                 "coa_defined_functions": sorted(coa_functions),
                 "saved_python_functions": [],
@@ -2862,6 +2953,7 @@ def tool_check_saved_generated_python_drift(
             "drift_detected": drift_detected,
             "method": "static_usercode_analysis",
             "python_payload_available": True,
+            "python_source": python_source,
             "ast_parse_succeeded": ast_ok,
             "coa_defined_functions": sorted(coa_functions),
             "saved_python_functions": sorted(saved_functions),
@@ -3179,41 +3271,10 @@ def tool_validate_playbook_bundle(
 
     checks: list[dict] = []
 
-    # Check 1 — SOAR structure validation endpoint
-    # SOAR 8.5 confirmed: /rest/playbook/{id}/validate does not exist → HTTP 400/404.
-    # passed_validation (check 2) serves as the structure signal on 8.5.
-    val_data, val_err = client.get(f"playbook/{current_id}/validate")
-    if val_err and ("404" in str(val_err) or "400" in str(val_err)):
-        checks.append({
-            "name": "validate_structure",
-            "status": "skipped",
-            "message": (
-                "SOAR 8.5: no dedicated /rest/playbook/{id}/validate endpoint "
-                "(HTTP 400/404). Use passed_validation flag (check 2) as structure signal."
-            ),
-            "details": {},
-        })
-    elif val_err:
-        checks.append({
-            "name": "validate_structure",
-            "status": "skipped",
-            "message": f"Validation endpoint error: {val_err}",
-            "details": {},
-        })
-    else:
-        # VERIFY: success signal in validation endpoint response
-        val_passed = (
-            val_data.get("success", True)
-            if isinstance(val_data, dict) else True
-        )
-        checks.append({
-            "name": "validate_structure",
-            "status": "passed" if val_passed else "failed",
-            "message": (val_data.get("message", "") if isinstance(val_data, dict) else ""),
-            "details": val_data if isinstance(val_data, dict) else {},
-        })
-
-    # Check 2 — REST passed_validation flag
+    # Check 1 — REST passed_validation flag.
+    # SOAR 8.5 has no /rest/playbook/{id}/validate endpoint; do not probe it,
+    # because that creates noisy server-side errors. The native flag is the
+    # structure signal for this SOAR generation.
     rest_data, rest_err = client.get(f"playbook/{current_id}")
     if rest_err or not isinstance(rest_data, dict):
         checks.append({
@@ -3231,7 +3292,7 @@ def tool_validate_playbook_bundle(
             "details": {},
         })
 
-    # Check 3 — COA node warnings
+    # Check 2 — COA node warnings
     nodes, _ = _get_graph(client, current_id, coa_data)
     w_count = sum(
         1 for n in nodes
@@ -3244,55 +3305,22 @@ def tool_validate_playbook_bundle(
         "details": {"warning_count": w_count},
     })
 
-    # Check 4 — Python py_compile (AST-only, no execution)
-    # SOAR 8.5: Python is not a REST field.  Priority order:
-    #   1. REST code field (rarely populated, kept for completeness)
-    #   2. COA userCode blocks (code-type nodes only)
-    #   3. Export archive .py file — covers action/decision/utility-only playbooks (#31 fix)
-    import io as _io
-    import tarfile as _tarfile
-
-    saved_python = None
-    python_source = None
-    if isinstance(rest_data, dict):
-        saved_python = (
-            rest_data.get("code")
-            or rest_data.get("script")
-            or rest_data.get("playbook_run_data")
-        )
-        if saved_python:
-            python_source = "rest_field"
-    if not saved_python:
-        saved_python = _extract_python_from_coa(nodes)
-        if saved_python:
-            python_source = "coa_usercode"
-    if not saved_python:
-        # Fetch export archive and extract the SOAR-generated .py file.
-        # SOAR generates Python for all node types (action, decision, utility, code),
-        # so the .py in the archive covers cases where COA has no code-type nodes.
-        export_content, _ = client.get_binary(f"playbook/{current_id}/export")
-        if export_content:
-            try:
-                buf = _io.BytesIO(export_content)
-                with _tarfile.open(fileobj=buf, mode="r:*") as tarf:
-                    for member in tarf.getmembers():
-                        if member.name.endswith(".py"):
-                            fobj = tarf.extractfile(member)
-                            if fobj:
-                                saved_python = fobj.read().decode("utf-8", errors="replace")
-                                python_source = "export_archive"
-                                break
-            except Exception:
-                pass  # archive extraction failed — proceed without compile check
+    # Check 3 — Python py_compile (AST-only, no execution)
+    saved_python, python_source = _select_playbook_python(
+        client,
+        current_id,
+        coa_data,
+        rest_data if isinstance(rest_data, dict) else {},
+        nodes,
+    )
 
     if not saved_python:
         checks.append({
             "name": "python_compile",
             "status": "skipped",
             "message": (
-                "No Python payload found — REST record has no code field, "
-                "COA contains no code-type nodes with userCode, "
-                "and export archive extraction failed or returned no .py file."
+                "No Python payload found in REST, COA, export archive, "
+                "or code-node userCode snippets."
             ),
             "details": {},
         })
@@ -3329,7 +3357,7 @@ def tool_validate_playbook_bundle(
             if tmp_path and _os.path.exists(tmp_path):
                 _os.unlink(tmp_path)
 
-    # Check 5 — lint (pyflakes preferred, pylint fallback; skip if absent)
+    # Check 4 — lint (pyflakes preferred, pylint fallback; skip if absent)
     lint_binary = _shutil.which("pyflakes") or _shutil.which("pylint")
     if not lint_binary or not saved_python:
         checks.append({

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -2042,29 +2042,50 @@ def _resolve_current_id(
         or coa_data.get("id")
         or pid
     )
-    return int(raw_current), coa_data, None
+    current_id = int(raw_current)
+
+    # SOAR 8.5 can return current_id while still returning the old revision's
+    # graph for /coa/playbooks/<old_id>. Refetch the current draft payload before
+    # any COA graph analysis so stale URLs do not poison downstream checks.
+    if current_id != pid:
+        current_data, current_err = client._coa_get(f"playbooks/{current_id}")
+        if not current_err and isinstance(current_data, dict):
+            return current_id, current_data, None
+
+    return current_id, coa_data, None
 
 
 def _get_coa_nodes_edges(coa_data: dict) -> tuple[list, list]:
     """
     Extract nodes and edges from a COA graph response.
 
-    Known shapes (issue #30 — second fix):
+    Known shapes:
       A) export archive JSON:   coa_data["coa"]["data"]["nodes"]
       B) live /coa/playbooks/{id} on SOAR 8.5 (no outer "coa" wrapper):
                                 coa_data["data"]["nodes"]
       C) flat top-level:        coa_data["nodes"]
+      D) older SOAR 8.5 hotfix shape:
+                                coa_data["coa_data"]["nodes"]
 
     Nodes may be a dict keyed by string node-id — normalised to list.
     Edges field may be "connections" or "edges".
     """
     coa_sub = coa_data.get("coa") or {}
+    coa_data_sub = coa_data.get("coa_data") or {}
+    if isinstance(coa_data_sub, str):
+        try:
+            coa_data_sub = json.loads(coa_data_sub)
+        except Exception:
+            coa_data_sub = {}
+    if not isinstance(coa_data_sub, dict):
+        coa_data_sub = {}
 
-    # data_sub: prefer shape A (coa.data), then shape B (data at top level)
-    data_sub = coa_sub.get("data") or coa_data.get("data") or {}
+    # data_sub: prefer shape A (coa.data), then B (top-level data), then D.
+    data_sub = coa_sub.get("data") or coa_data.get("data") or coa_data_sub or {}
 
     nodes_raw = (
         data_sub.get("nodes")        # shapes A and B
+        or coa_data_sub.get("nodes") # shape D
         or coa_sub.get("nodes")      # coa.nodes (uncommon fallback)
         or coa_data.get("nodes")     # shape C
         or {}
@@ -2078,13 +2099,61 @@ def _get_coa_nodes_edges(coa_data: dict) -> tuple[list, list]:
 
     edges_raw = (
         data_sub.get("connections") or data_sub.get("edges")
+        or coa_data_sub.get("connections") or coa_data_sub.get("edges")
         or coa_sub.get("connections") or coa_sub.get("edges")
         or coa_data.get("connections") or coa_data.get("edges")
         or coa_data.get("links")
         or []
     )
     edges: list = edges_raw if isinstance(edges_raw, list) else []
-    return nodes, edges
+
+    def _issue_list(value: Any) -> list:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [v for v in value.values() if v]
+        return []
+
+    normalized_nodes: list[dict] = []
+    node_name_by_id: dict[str, str] = {}
+    for raw in nodes:
+        if not isinstance(raw, dict):
+            continue
+        data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
+        rec = dict(data) if data else dict(raw)
+
+        node_id = raw.get("id", rec.get("id"))
+        if node_id is not None:
+            rec["id"] = node_id
+            rec["node_id"] = node_id
+        rec["x"] = raw.get("x", rec.get("x", 0))
+        rec["y"] = raw.get("y", rec.get("y", 0))
+        rec["warnings"] = _issue_list(raw.get("warnings", rec.get("warnings", [])))
+        rec["errors"] = _issue_list(raw.get("errors", rec.get("errors", [])))
+        if "userCode" in raw and "userCode" not in rec:
+            rec["userCode"] = raw.get("userCode")
+
+        fn_name = rec.get("functionName") or rec.get("function_name") or rec.get("name") or ""
+        if node_id is not None:
+            node_name_by_id[str(node_id)] = str(fn_name)
+        normalized_nodes.append(rec)
+
+    normalized_edges: list[dict] = []
+    for raw in edges:
+        if not isinstance(raw, dict):
+            continue
+        rec = dict(raw)
+        src_id = rec.get("source") or rec.get("source_id") or rec.get("from") or rec.get("sourceNode")
+        tgt_id = rec.get("target") or rec.get("target_id") or rec.get("to") or rec.get("targetNode")
+        if src_id is not None:
+            rec["source"] = src_id
+            rec.setdefault("source_function", node_name_by_id.get(str(src_id), str(src_id)))
+        if tgt_id is not None:
+            rec["target"] = tgt_id
+            rec.setdefault("target_function", node_name_by_id.get(str(tgt_id), str(tgt_id)))
+        normalized_edges.append(rec)
+
+    return normalized_nodes, normalized_edges
 
 
 def _coa_shape_debug(coa_data: dict) -> dict:
@@ -2465,7 +2534,13 @@ def tool_get_playbook_coa_summary(
     passed_validation = rest_data.get("passed_validation", coa_data.get("passed_validation", False))
     # VERIFY: playbook_type / trigger field names
     playbook_type = rest_data.get("playbook_type") or coa_data.get("playbook_type", "")
-    trigger = rest_data.get("trigger") or coa_data.get("trigger", "")
+    trigger = (
+        rest_data.get("playbook_trigger")
+        or rest_data.get("trigger")
+        or coa_data.get("playbook_trigger")
+        or coa_data.get("trigger")
+        or ""
+    )
 
     findings = []
     if warning_count:

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -1273,13 +1273,9 @@ def tool_list_case_notes(client: SoarApiClient, config: McpServerConfig, args: d
 def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: dict) -> str:
     """List available SOAR playbooks."""
     active_only = args.get("active_only", True)
-    category = args.get("category", "")
+    category = (args.get("category", "") or "").strip()
 
     params: dict = {"page_size": config.max_results}
-    if active_only:
-        params["_filter_active"] = "true"  # SOAR requires lowercase (bug #7)
-    if category:
-        params["_filter_category__icontains"] = f'"{category}"'
 
     data, err = client.get("playbook", params=params)
     if err:
@@ -1287,6 +1283,11 @@ def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: di
 
     items = data if isinstance(data, list) else data.get("data", [])
     total = data.get("count", len(items)) if isinstance(data, dict) else len(items)
+    if active_only:
+        items = [pb for pb in items if bool(pb.get("active"))]
+    if category:
+        cat = category.lower()
+        items = [pb for pb in items if cat in str(pb.get("category", "")).lower()]
     if not items:
         return "No playbooks found."
 

--- a/test_soar_mcp_soar85_coa_summary.py
+++ b/test_soar_mcp_soar85_coa_summary.py
@@ -1,0 +1,94 @@
+"""Regression coverage for SOAR 8.5 COA graph and summary behavior."""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import (
+    _get_coa_nodes_edges,
+    _resolve_current_id,
+    tool_get_playbook_coa_summary,
+)
+
+
+class _FakeCoaClient:
+    def __init__(self) -> None:
+        self.coa = {
+            "id": 180,
+            "current_id": 180,
+            "playbook_trigger": "artifact_created",
+            "coa_data": {
+                "nodes": {
+                    "0": {
+                        "id": "0",
+                        "x": 10,
+                        "y": 20,
+                        "data": {"type": "code", "functionName": "do_work"},
+                    }
+                },
+                "edges": [],
+            },
+        }
+
+    def get(self, path, params=None):
+        if path == "playbook/180":
+            return {
+                "id": 180,
+                "name": "Quarantine",
+                "version": 9,
+                "playbook_trigger": "artifact_created",
+                "passed_validation": True,
+            }, None
+        return {}, None
+
+    def _coa_get(self, path, params=None):
+        return self.coa, None
+
+    def get_binary(self, path, params=None):
+        return b"", None
+
+
+class _StaleCoaClient:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def _coa_get(self, path, params=None):
+        self.calls.append(path)
+        if path == "playbooks/172":
+            return {"id": 172, "current_id": 180, "coa_data": {"nodes": {"old": {}}}}, None
+        if path == "playbooks/180":
+            return {"id": 180, "current_id": 180, "coa_data": {"nodes": {"current": {}}}}, None
+        return {}, None
+
+
+class Soar85CoaSummaryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = McpServerConfig()
+        self.cfg.advisory_disclaimer = False
+
+    def test_coa_data_shape_is_normalized(self):
+        client = _FakeCoaClient()
+        nodes, edges = _get_coa_nodes_edges(client.coa)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(len(edges), 0)
+        self.assertEqual(nodes[0]["functionName"], "do_work")
+        self.assertEqual(nodes[0]["x"], 10)
+
+    def test_resolve_current_id_refetches_current_payload(self):
+        client = _StaleCoaClient()
+        current_id, coa_data, err = _resolve_current_id(client, 172)
+        self.assertIsNone(err)
+        self.assertEqual(current_id, 180)
+        self.assertEqual(coa_data["id"], 180)
+        self.assertEqual(client.calls, ["playbooks/172", "playbooks/180"])
+
+    def test_coa_summary_reads_playbook_trigger(self):
+        client = _FakeCoaClient()
+        data = json.loads(tool_get_playbook_coa_summary(client, self.cfg, {"playbook_id": 180}))
+        self.assertEqual(data["data"]["trigger"], "artifact_created")
+        self.assertEqual(data["data"]["node_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_soar85_list_playbooks.py
+++ b/test_soar_mcp_soar85_list_playbooks.py
@@ -1,0 +1,41 @@
+"""Regression coverage for SOAR 8.5 playbook listing behavior."""
+from __future__ import annotations
+
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import tool_list_playbooks
+
+
+class _FakePlaybookClient:
+    def __init__(self) -> None:
+        self.get_calls: list[tuple[str, dict | None]] = []
+
+    def get(self, path, params=None):
+        self.get_calls.append((path, params))
+        if path == "playbook":
+            return {
+                "data": [
+                    {"id": 1, "name": "Active PB", "active": True, "category": "response"},
+                    {"id": 2, "name": "Inactive PB", "active": False, "category": "response"},
+                ],
+                "count": 2,
+            }, None
+        return {}, None
+
+
+class Soar85ListPlaybooksTest(unittest.TestCase):
+    def test_list_playbooks_filters_active_locally(self):
+        cfg = McpServerConfig()
+        cfg.advisory_disclaimer = False
+        client = _FakePlaybookClient()
+
+        out = tool_list_playbooks(client, cfg, {"active_only": True})
+
+        self.assertIn("Active PB", out)
+        self.assertNotIn("Inactive PB", out)
+        self.assertEqual(client.get_calls[0], ("playbook", {"page_size": 50}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_soar85_validation_drift.py
+++ b/test_soar_mcp_soar85_validation_drift.py
@@ -1,0 +1,89 @@
+"""Regression coverage for SOAR 8.5 validation and Python drift checks."""
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import (
+    tool_check_saved_generated_python_drift,
+    tool_validate_playbook_bundle,
+)
+
+
+def _tar_with_python(source: str) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tarf:
+        payload = source.encode("utf-8")
+        info = tarfile.TarInfo("playbook.py")
+        info.size = len(payload)
+        tarf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+class _FakeValidationClient:
+    def __init__(self) -> None:
+        self.coa = {
+            "id": 180,
+            "current_id": 180,
+            "coa_data": {
+                "nodes": {
+                    "0": {
+                        "id": "0",
+                        "data": {"type": "code", "functionName": "do_work"},
+                    }
+                },
+                "edges": [],
+            },
+            "python": (
+                "def on_start(container):\n"
+                "    do_work(container)\n\n"
+                "def do_work(container):\n"
+                "    return None\n\n"
+                "def on_finish(container, summary):\n"
+                "    return None\n"
+            ),
+        }
+
+    def get(self, path, params=None):
+        if path == "playbook/180":
+            return {
+                "id": 180,
+                "name": "Quarantine",
+                "version": 9,
+                "passed_validation": True,
+            }, None
+        if path == "playbook/180/validate":
+            raise AssertionError("SOAR 8.5 validate endpoint must not be called")
+        return {}, None
+
+    def _coa_get(self, path, params=None):
+        return self.coa, None
+
+    def get_binary(self, path, params=None):
+        return _tar_with_python(self.coa["python"]), None
+
+
+class Soar85ValidationDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = McpServerConfig()
+        self.cfg.advisory_disclaimer = False
+        self.client = _FakeValidationClient()
+
+    def test_validate_bundle_does_not_probe_validate_endpoint(self):
+        data = json.loads(tool_validate_playbook_bundle(self.client, self.cfg, {"playbook_id": 180}))
+        names = [c["name"] for c in data["data"]["checks"]]
+        self.assertNotIn("validate_structure", names)
+        self.assertEqual(data["ok"], True)
+
+    def test_drift_check_uses_coa_python_payload(self):
+        data = json.loads(tool_check_saved_generated_python_drift(self.client, self.cfg, {"playbook_id": 180}))
+        self.assertEqual(data["data"]["status"], "completed")
+        self.assertEqual(data["data"]["python_source"], "coa_python")
+        self.assertEqual(data["ok"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Use SOAR 8.5 Python payloads for validation and drift checks

## Summary
- Stop probing `/rest/playbook/{id}/validate`, which is not a valid SOAR 8.5
  playbook endpoint.
- Prefer full generated Python from REST/COA/export payloads before falling back
  to COA user-code snippets.
- Dedent snippet fallback code so generated indentation does not create false
  `py_compile` failures.
- Treat `on_start`, `on_finish`, function nodes and callbacks as COA-owned for
  drift detection.

## Why
The Visual Editor checks should not report false failures caused by an invalid
validation endpoint or by compiling partial indented snippets instead of the
saved/generated Python payload.

## Validation
```bash
python3 -m py_compile soar_mcp_tools.py
python3 -m unittest test_soar_mcp_soar85_validation_drift -v
```

## Local branch
`upstream/pr3-soar85-validation-drift-python`

## Stack note
This is part of a five-PR SOAR 8.5 compatibility series.
Preferred focused review base: `upstream/pr2-soar85-coa-current-summary`.
GitHub upstream PRs target `main` because this account does not have permission to create intermediate base branches in `abuis78/soar_mcp_server`.
