### PR TITLE
Document generated handler endpoint and expose SSL verification override

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Transform Splunk SOAR into an MCP (Model Context Protocol) server endpoint for d
                          │  Authentication: ph-auth-token header
                          ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  https://<your-soar>/rest/handler/phantom_soar_mcp_server/mcp │
+│  https://<your-soar>/rest/handler/soarmcpserver_<appid>/<asset> │
 │  ┌───────────────────────────────────────────────────────┐  │
 │  │  SOAR MCP Server App (Python REST Handler)           │  │
 │  │  ├─ Tool Registry (asset config checkboxes)          │  │
@@ -83,8 +83,11 @@ Transform Splunk SOAR into an MCP (Model Context Protocol) server endpoint for d
 
 The app installs immediately and the MCP endpoint becomes active at:
 ```
-https://<your-soar>/rest/handler/phantom_soar_mcp_server/mcp
+https://<your-soar>/rest/handler/soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/<asset_name>
 ```
+
+Use the endpoint shown by **Test Connectivity** or **Get MCP Config**. The last
+path segment is the SOAR asset name, for example `mcp`.
 
 ### Step 2: Configure the Asset
 
@@ -139,7 +142,7 @@ All tools are individually enabled/disabled via checkboxes. See [Available Tools
 {
   "mcpServers": {
     "splunk-soar": {
-      "url": "https://soar.example.com/rest/handler/phantom_soar_mcp_server/mcp",
+      "url": "https://soar.example.com/rest/handler/soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/mcp",
       "headers": {
         "ph-auth-token": "YOUR_SOAR_AUTH_TOKEN"
       }
@@ -155,7 +158,7 @@ Save and restart Claude Desktop. Verify: look for "splunk-soar" in the bottom-le
 ```bash
 claude mcp add splunk-soar \
   --transport http \
-  --url "https://soar.example.com/rest/handler/phantom_soar_mcp_server/mcp" \
+  --url "https://soar.example.com/rest/handler/soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/mcp" \
   --header "ph-auth-token: YOUR_SOAR_AUTH_TOKEN"
 ```
 
@@ -170,7 +173,7 @@ claude mcp list
 **Prerequisites:** Enterprise Claude.ai subscription with MCP connector support; SOAR accessible from the internet or via VPN/proxy.
 
 1. Claude.ai → **Settings → Integrations → MCP Servers → + Add Server**
-2. **URL**: `https://soar.example.com/rest/handler/phantom_soar_mcp_server/mcp`
+2. **URL**: `https://soar.example.com/rest/handler/soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/mcp`
 3. **Auth Type**: Custom Header — `ph-auth-token: YOUR_SOAR_AUTH_TOKEN`
 
 > ⚠️ When using Claude.ai, SOAR case data (titles, descriptions, artifact values, analyst notes) transits Anthropic's cloud infrastructure. Review [Anthropic's data retention policy](https://www.anthropic.com/legal/privacy) before connecting a production SOAR instance.
@@ -179,9 +182,9 @@ claude mcp list
 
 | Issue | Solution |
 |-------|----------|
-| "Connection refused" | `curl -I https://soar.example.com/rest/handler/phantom_soar_mcp_server/mcp` |
+| "Connection refused" | `curl -I https://soar.example.com/rest/handler/soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/mcp` |
 | "Unauthorized" | Check auth token in SOAR UI → User Management |
-| "SSL certificate verify failed" | Add SOAR's SSL cert to system trust store, or set `ssl_verify = false` in `local/mcp.conf` (testing only) |
+| "SSL certificate verify failed" | Add SOAR's SSL cert to system trust store, or disable **SSL Verify** in the SOAR asset config for test instances only |
 | Tools not appearing | Run **Test Connectivity** to refresh tool registry |
 | "Tool disabled" error | Enable tool checkbox in asset config → Test Connectivity |
 
@@ -271,6 +274,7 @@ All configuration is managed from **SOAR UI → Apps → SOAR MCP Server → Ass
 |-------|------|---------|
 | **Base URL** | String | SOAR instance URL for Test Connectivity validation |
 | **Auth Token** | Password | SOAR authorization token |
+| **SSL Verify** | Boolean | Verify TLS certs for handler API callbacks; disable only for test/self-signed instances |
 | **AI Instructions** | Text | Context injected into every MCP session |
 | **enable_test_harness** | Boolean | Enables test harness / `create_container` tool (v1.6.9+) |
 | **scoped_tokens_enabled** | Boolean | Enable per-user scoped tokens (v1.5.0+) |
@@ -427,7 +431,7 @@ SOAR:   [Executes, logs with analyst approval reference]
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | "Missing app directory" on install | TAR lacks top-level directory entry | Rebuild from parent dir: `cd /parent && tar -czf app.tar soar_mcp_server/` |
-| "Connection refused" | MCP endpoint not accessible | `curl -I https://soar.example.com/rest/handler/phantom_soar_mcp_server/mcp` |
+| "Connection refused" | MCP endpoint not accessible | `curl -I https://soar.example.com/rest/handler/soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/mcp` |
 | "Unauthorized" | Invalid auth token | Regenerate token in SOAR UI |
 | node_count = 0 | COA endpoint empty on SOAR 8.5 | Fixed in v1.6.5 — export archive fallback is automatic |
 | Python compile skipped | No `code`-type nodes | Fixed in v1.6.6 — Python extracted from export archive automatically |

--- a/__init__.py
+++ b/__init__.py
@@ -5,4 +5,4 @@
 # MCP handler:    soar_mcp_handler.SoarMcpRestHandler
 # Config file:    local/mcp.conf  (override default/mcp.conf)
 # Token store:    local/mcp_tokens.json  (v1.5.0+, scoped MCP tokens)
-# MCP endpoint:   https://<soar>/rest/handler/phantom_soar_mcp_server/mcp
+# MCP endpoint:   https://<soar>/rest/handler/soarmcpserver_<appid>/<asset_name>

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -331,6 +331,13 @@ class McpConfigLoader:
         if eth is not None:
             config.enable_test_harness = bool(eth)
 
+        ssl_override = overrides.get("ssl_verify")
+        if ssl_override is not None:
+            if isinstance(ssl_override, bool):
+                config.ssl_verify = ssl_override
+            else:
+                config.ssl_verify = self._parse_ssl_verify(str(ssl_override))
+
         # Persist MCP endpoint URL so tools can display it
         mcp_ep = overrides.get("mcp_endpoint")
         if mcp_ep and isinstance(mcp_ep, str):

--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -151,6 +151,9 @@ class SoarMcpConnector(BaseConnector):
         eth_val = asset_cfg.get("enable_test_harness")
         enable_test_harness = bool(eth_val) if eth_val is not None else None
 
+        ssl_val = asset_cfg.get("ssl_verify")
+        ssl_verify = bool(ssl_val) if ssl_val is not None else None
+
         # Build the correct MCP endpoint URL (base_url is from asset config for
         # test connectivity; the real base_url is also detected by the handler
         # from the incoming request and will overwrite this on first MCP call).
@@ -162,6 +165,7 @@ class SoarMcpConnector(BaseConnector):
             "tools": tool_overrides,
             "ai_instructions": ai_instructions,
             "enable_test_harness": enable_test_harness,
+            "ssl_verify": ssl_verify,
             "asset_name": self._asset_name,
             "base_url": self._base_url,
             "auth_token": self._auth_token,

--- a/soar_mcp_handler.py
+++ b/soar_mcp_handler.py
@@ -291,7 +291,11 @@ class SoarMcpRestHandler(dict):
             # Return -32602 Invalid Params (not -32603 Internal Server Error) (fix #12)
             raise _InvalidParamsError("tools/call requires a non-empty 'name' parameter")
 
-        if tool_name not in config.enabled_tools:
+        safe_layout_preview = (
+            tool_name == "save_playbook_layout_only"
+            and bool(arguments.get("dry_run", True))
+        )
+        if tool_name not in config.enabled_tools and not safe_layout_preview:
             if tool_name in TOOL_SCHEMAS:
                 text = (f"Tool '{tool_name}' is disabled. Enable it in the SOAR MCP Server "
                         f"asset configuration and run Test Connectivity.")
@@ -312,7 +316,22 @@ class SoarMcpRestHandler(dict):
 
         self._audit_tool_call(token_verification, tool_name, arguments, outcome="ok")
         result_text = call_tool(tool_name, arguments, client, config)
-        return {"content": [{"type": "text", "text": result_text}], "isError": False}
+        is_error = self._is_tool_error(result_text)
+        return {"content": [{"type": "text", "text": result_text}], "isError": is_error}
+
+    @staticmethod
+    def _is_tool_error(result_text: str) -> bool:
+        """Best-effort MCP isError flag for existing text and structured JSON tool outputs."""
+        text = result_text.lstrip()
+        if text.startswith(("Error:", "Error ")):
+            return True
+        try:
+            payload = json.loads(text)
+        except Exception:
+            return False
+        if isinstance(payload, dict):
+            return payload.get("ok") is False or bool(payload.get("errors"))
+        return False
 
     @staticmethod
     def _audit_tool_call(token_verification, tool_name: str,

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -46,11 +46,18 @@
             "required": false,
             "order": 1
         },
+        "ssl_verify": {
+            "description": "Verify TLS certificates for SOAR API callbacks from the MCP handler. Keep enabled for trusted/public URLs. Disable only on test instances that use a self-signed certificate.",
+            "data_type": "boolean",
+            "default": true,
+            "required": false,
+            "order": 2
+        },
         "ai_instructions": {
             "description": "Additional context sent to the AI on every MCP session (appended to the built-in instructions). Use this to describe your SOAR environment, naming conventions, severity triage rules, escalation procedures, or any SOC-specific context the AI should know. Example: 'Cases labeled phishing should always be escalated if severity is high. Owner format is firstname.lastname.'",
             "data_type": "string",
             "required": false,
-            "order": 2
+            "order": 3
         },
         "tool_list_cases": {
             "description": "READ \u2014 list_cases: List SOAR cases with status/severity/label/owner filters.",

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import textwrap
 from typing import Any, Optional
 
 import requests
@@ -2232,6 +2233,28 @@ def _get_graph(
     return nodes, edges
 
 
+def _extract_python_from_export(client: "SoarApiClient", playbook_id: int) -> Optional[str]:
+    """Return the generated .py payload from a playbook export archive."""
+    import io as _io_py
+    import tarfile as _tarfile_py
+
+    content, _ = client.get_binary(f"playbook/{playbook_id}/export")
+    if not content:
+        return None
+    try:
+        buf = _io_py.BytesIO(content)
+        with _tarfile_py.open(fileobj=buf, mode="r:*") as tarf:
+            for member in tarf.getmembers():
+                if not member.name.endswith(".py"):
+                    continue
+                fobj = tarf.extractfile(member)
+                if fobj:
+                    return fobj.read().decode("utf-8", errors="replace")
+    except Exception:
+        return None
+    return None
+
+
 def _extract_python_from_coa(nodes: list) -> Optional[str]:
     """
     Reconstruct a Python payload from COA userCode blocks.
@@ -2251,8 +2274,88 @@ def _extract_python_from_coa(nodes: list) -> Optional[str]:
             fn_name = (
                 n.get("functionName") or n.get("function_name") or n.get("name") or "block"
             )
-            parts.append(f"# --- {fn_name} ---\n{code}")
+            parts.append(f"# --- {fn_name} ---\n{textwrap.dedent(str(code)).strip()}")
     return "\n\n".join(parts) if parts else None
+
+
+def _extract_python_from_coa_payload(coa_data: dict) -> Optional[str]:
+    """Return full generated Python from known COA envelope fields, if present."""
+    candidates: list[Any] = [
+        coa_data.get("python"),
+        coa_data.get("code"),
+        (coa_data.get("coa") or {}).get("python") if isinstance(coa_data.get("coa"), dict) else None,
+        (coa_data.get("coa") or {}).get("code") if isinstance(coa_data.get("coa"), dict) else None,
+    ]
+    data_sub = (coa_data.get("coa") or {}).get("data") if isinstance(coa_data.get("coa"), dict) else None
+    if not data_sub and isinstance(coa_data.get("data"), dict):
+        data_sub = coa_data.get("data")
+    if isinstance(data_sub, dict):
+        candidates.extend([data_sub.get("python"), data_sub.get("code")])
+    for value in candidates:
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _select_playbook_python(
+    client: "SoarApiClient",
+    current_id: int,
+    coa_data: dict,
+    rest_data: dict | None,
+    nodes: list,
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Return the best full Python payload for validation/drift checks.
+
+    Prefer full generated sources (REST/COA/export) over node snippets. Node
+    snippets are a last resort because SOAR may store them indented relative to
+    generated wrapper code, which can false-fail py_compile.
+    """
+    if isinstance(rest_data, dict):
+        for key in ("code", "script", "playbook_run_data", "python"):
+            value = rest_data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value, f"rest_{key}"
+
+    coa_python = _extract_python_from_coa_payload(coa_data)
+    if coa_python:
+        return coa_python, "coa_python"
+
+    export_python = _extract_python_from_export(client, current_id)
+    if export_python:
+        return export_python, "export_archive"
+
+    snippet_python = _extract_python_from_coa(nodes)
+    if snippet_python:
+        return snippet_python, "coa_usercode_snippets"
+
+    return None, None
+
+
+def _collect_coa_owned_function_names(nodes: list) -> set[str]:
+    """Collect generated function names that are owned by the COA graph."""
+    import ast as _ast_owned
+
+    names: set[str] = {"on_start", "on_finish"}
+    for n in nodes:
+        if not isinstance(n, dict):
+            continue
+        fn_name = n.get("functionName") or n.get("function_name") or n.get("name")
+        if fn_name:
+            fn = str(fn_name)
+            names.add(fn)
+            names.add(f"{fn}_callback")
+        code = n.get("userCode") or n.get("user_code") or n.get("code") or ""
+        if code:
+            try:
+                tree = _ast_owned.parse(textwrap.dedent(str(code)))
+                for node_obj in _ast_owned.walk(tree):
+                    if isinstance(node_obj, _ast_owned.FunctionDef):
+                        names.add(node_obj.name)
+                        names.add(f"{node_obj.name}_callback")
+            except SyntaxError:
+                pass
+    return names
 
 
 def _normalize_coa_volatile(data: object, _depth: int = 0) -> object:
@@ -2755,40 +2858,23 @@ def tool_check_saved_generated_python_drift(
         errors.append({"source": "coa", "message": err})
 
     nodes, _ = _get_graph(client, current_id, coa_data)
+    coa_functions = _collect_coa_owned_function_names(nodes)
 
-    # Collect COA userCode blocks from code-type nodes
-    # VERIFY: field name "userCode" inside a code node — may be "user_code" or "code"
-    coa_functions: set[str] = set()
-    for n in nodes:
-        if (n.get("type") or "").lower() == "code":
-            user_code = n.get("userCode") or n.get("user_code") or n.get("code") or ""
-            if user_code:
-                try:
-                    tree = _ast.parse(user_code)
-                    for node_obj in _ast.walk(tree):
-                        if isinstance(node_obj, _ast.FunctionDef):
-                            coa_functions.add(node_obj.name)
-                except SyntaxError:
-                    pass
-
-    # Fetch saved Python payload from REST
-    # VERIFY: field name for saved Python in /rest/playbook/{id} — may be "code", "script", or "playbook_run_data"
     rest_data, rest_err = client.get(f"playbook/{current_id}")
-    saved_python: Optional[str] = None
-    python_payload_available = False
-    if isinstance(rest_data, dict):
-        saved_python = (
-            rest_data.get("code")
-            or rest_data.get("script")
-            or rest_data.get("playbook_run_data")
-        )
-        if saved_python:
-            python_payload_available = True
+    if rest_err:
+        errors.append({"source": "rest", "message": rest_err})
+    saved_python, python_source = _select_playbook_python(
+        client,
+        current_id,
+        coa_data,
+        rest_data if isinstance(rest_data, dict) else {},
+        nodes,
+    )
 
-    if not python_payload_available:
+    if not saved_python:
         result = {
-            "ok": True,
-            "summary": "Python payload not available in REST response — check skipped.",
+            "ok": False,
+            "summary": "Python payload not available from REST, COA, or export archive — check skipped.",
             "data": {
                 "current_id": current_id,
                 "drift_detected": False,
@@ -2799,9 +2885,13 @@ def tool_check_saved_generated_python_drift(
                 "saved_python_functions": [],
                 "external_helper_candidates": [],
                 "status": "skipped",
-                "skip_reason": "saved Python payload not found in /rest/playbook response — VERIFY field name",  # noqa
+                "skip_reason": "saved Python payload not found in REST, COA, or export archive",
             },
-            "findings": [],
+            "findings": [{
+                "severity": "warn",
+                "code": "python_payload_unavailable",
+                "message": "Could not inspect generated Python; drift status is unknown.",
+            }],
             "errors": errors,
         }
         return json.dumps(result, indent=2)
@@ -2825,6 +2915,7 @@ def tool_check_saved_generated_python_drift(
                 "drift_detected": False,
                 "method": "fallback_unavailable",
                 "python_payload_available": True,
+                "python_source": python_source,
                 "ast_parse_succeeded": False,
                 "coa_defined_functions": sorted(coa_functions),
                 "saved_python_functions": [],
@@ -2862,6 +2953,7 @@ def tool_check_saved_generated_python_drift(
             "drift_detected": drift_detected,
             "method": "static_usercode_analysis",
             "python_payload_available": True,
+            "python_source": python_source,
             "ast_parse_succeeded": ast_ok,
             "coa_defined_functions": sorted(coa_functions),
             "saved_python_functions": sorted(saved_functions),
@@ -3179,41 +3271,10 @@ def tool_validate_playbook_bundle(
 
     checks: list[dict] = []
 
-    # Check 1 — SOAR structure validation endpoint
-    # SOAR 8.5 confirmed: /rest/playbook/{id}/validate does not exist → HTTP 400/404.
-    # passed_validation (check 2) serves as the structure signal on 8.5.
-    val_data, val_err = client.get(f"playbook/{current_id}/validate")
-    if val_err and ("404" in str(val_err) or "400" in str(val_err)):
-        checks.append({
-            "name": "validate_structure",
-            "status": "skipped",
-            "message": (
-                "SOAR 8.5: no dedicated /rest/playbook/{id}/validate endpoint "
-                "(HTTP 400/404). Use passed_validation flag (check 2) as structure signal."
-            ),
-            "details": {},
-        })
-    elif val_err:
-        checks.append({
-            "name": "validate_structure",
-            "status": "skipped",
-            "message": f"Validation endpoint error: {val_err}",
-            "details": {},
-        })
-    else:
-        # VERIFY: success signal in validation endpoint response
-        val_passed = (
-            val_data.get("success", True)
-            if isinstance(val_data, dict) else True
-        )
-        checks.append({
-            "name": "validate_structure",
-            "status": "passed" if val_passed else "failed",
-            "message": (val_data.get("message", "") if isinstance(val_data, dict) else ""),
-            "details": val_data if isinstance(val_data, dict) else {},
-        })
-
-    # Check 2 — REST passed_validation flag
+    # Check 1 — REST passed_validation flag.
+    # SOAR 8.5 has no /rest/playbook/{id}/validate endpoint; do not probe it,
+    # because that creates noisy server-side errors. The native flag is the
+    # structure signal for this SOAR generation.
     rest_data, rest_err = client.get(f"playbook/{current_id}")
     if rest_err or not isinstance(rest_data, dict):
         checks.append({
@@ -3231,7 +3292,7 @@ def tool_validate_playbook_bundle(
             "details": {},
         })
 
-    # Check 3 — COA node warnings
+    # Check 2 — COA node warnings
     nodes, _ = _get_graph(client, current_id, coa_data)
     w_count = sum(
         1 for n in nodes
@@ -3244,55 +3305,22 @@ def tool_validate_playbook_bundle(
         "details": {"warning_count": w_count},
     })
 
-    # Check 4 — Python py_compile (AST-only, no execution)
-    # SOAR 8.5: Python is not a REST field.  Priority order:
-    #   1. REST code field (rarely populated, kept for completeness)
-    #   2. COA userCode blocks (code-type nodes only)
-    #   3. Export archive .py file — covers action/decision/utility-only playbooks (#31 fix)
-    import io as _io
-    import tarfile as _tarfile
-
-    saved_python = None
-    python_source = None
-    if isinstance(rest_data, dict):
-        saved_python = (
-            rest_data.get("code")
-            or rest_data.get("script")
-            or rest_data.get("playbook_run_data")
-        )
-        if saved_python:
-            python_source = "rest_field"
-    if not saved_python:
-        saved_python = _extract_python_from_coa(nodes)
-        if saved_python:
-            python_source = "coa_usercode"
-    if not saved_python:
-        # Fetch export archive and extract the SOAR-generated .py file.
-        # SOAR generates Python for all node types (action, decision, utility, code),
-        # so the .py in the archive covers cases where COA has no code-type nodes.
-        export_content, _ = client.get_binary(f"playbook/{current_id}/export")
-        if export_content:
-            try:
-                buf = _io.BytesIO(export_content)
-                with _tarfile.open(fileobj=buf, mode="r:*") as tarf:
-                    for member in tarf.getmembers():
-                        if member.name.endswith(".py"):
-                            fobj = tarf.extractfile(member)
-                            if fobj:
-                                saved_python = fobj.read().decode("utf-8", errors="replace")
-                                python_source = "export_archive"
-                                break
-            except Exception:
-                pass  # archive extraction failed — proceed without compile check
+    # Check 3 — Python py_compile (AST-only, no execution)
+    saved_python, python_source = _select_playbook_python(
+        client,
+        current_id,
+        coa_data,
+        rest_data if isinstance(rest_data, dict) else {},
+        nodes,
+    )
 
     if not saved_python:
         checks.append({
             "name": "python_compile",
             "status": "skipped",
             "message": (
-                "No Python payload found — REST record has no code field, "
-                "COA contains no code-type nodes with userCode, "
-                "and export archive extraction failed or returned no .py file."
+                "No Python payload found in REST, COA, export archive, "
+                "or code-node userCode snippets."
             ),
             "details": {},
         })
@@ -3329,7 +3357,7 @@ def tool_validate_playbook_bundle(
             if tmp_path and _os.path.exists(tmp_path):
                 _os.unlink(tmp_path)
 
-    # Check 5 — lint (pyflakes preferred, pylint fallback; skip if absent)
+    # Check 4 — lint (pyflakes preferred, pylint fallback; skip if absent)
     lint_binary = _shutil.which("pyflakes") or _shutil.which("pylint")
     if not lint_binary or not saved_python:
         checks.append({

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -2042,29 +2042,50 @@ def _resolve_current_id(
         or coa_data.get("id")
         or pid
     )
-    return int(raw_current), coa_data, None
+    current_id = int(raw_current)
+
+    # SOAR 8.5 can return current_id while still returning the old revision's
+    # graph for /coa/playbooks/<old_id>. Refetch the current draft payload before
+    # any COA graph analysis so stale URLs do not poison downstream checks.
+    if current_id != pid:
+        current_data, current_err = client._coa_get(f"playbooks/{current_id}")
+        if not current_err and isinstance(current_data, dict):
+            return current_id, current_data, None
+
+    return current_id, coa_data, None
 
 
 def _get_coa_nodes_edges(coa_data: dict) -> tuple[list, list]:
     """
     Extract nodes and edges from a COA graph response.
 
-    Known shapes (issue #30 — second fix):
+    Known shapes:
       A) export archive JSON:   coa_data["coa"]["data"]["nodes"]
       B) live /coa/playbooks/{id} on SOAR 8.5 (no outer "coa" wrapper):
                                 coa_data["data"]["nodes"]
       C) flat top-level:        coa_data["nodes"]
+      D) older SOAR 8.5 hotfix shape:
+                                coa_data["coa_data"]["nodes"]
 
     Nodes may be a dict keyed by string node-id — normalised to list.
     Edges field may be "connections" or "edges".
     """
     coa_sub = coa_data.get("coa") or {}
+    coa_data_sub = coa_data.get("coa_data") or {}
+    if isinstance(coa_data_sub, str):
+        try:
+            coa_data_sub = json.loads(coa_data_sub)
+        except Exception:
+            coa_data_sub = {}
+    if not isinstance(coa_data_sub, dict):
+        coa_data_sub = {}
 
-    # data_sub: prefer shape A (coa.data), then shape B (data at top level)
-    data_sub = coa_sub.get("data") or coa_data.get("data") or {}
+    # data_sub: prefer shape A (coa.data), then B (top-level data), then D.
+    data_sub = coa_sub.get("data") or coa_data.get("data") or coa_data_sub or {}
 
     nodes_raw = (
         data_sub.get("nodes")        # shapes A and B
+        or coa_data_sub.get("nodes") # shape D
         or coa_sub.get("nodes")      # coa.nodes (uncommon fallback)
         or coa_data.get("nodes")     # shape C
         or {}
@@ -2078,13 +2099,61 @@ def _get_coa_nodes_edges(coa_data: dict) -> tuple[list, list]:
 
     edges_raw = (
         data_sub.get("connections") or data_sub.get("edges")
+        or coa_data_sub.get("connections") or coa_data_sub.get("edges")
         or coa_sub.get("connections") or coa_sub.get("edges")
         or coa_data.get("connections") or coa_data.get("edges")
         or coa_data.get("links")
         or []
     )
     edges: list = edges_raw if isinstance(edges_raw, list) else []
-    return nodes, edges
+
+    def _issue_list(value: Any) -> list:
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [v for v in value.values() if v]
+        return []
+
+    normalized_nodes: list[dict] = []
+    node_name_by_id: dict[str, str] = {}
+    for raw in nodes:
+        if not isinstance(raw, dict):
+            continue
+        data = raw.get("data") if isinstance(raw.get("data"), dict) else {}
+        rec = dict(data) if data else dict(raw)
+
+        node_id = raw.get("id", rec.get("id"))
+        if node_id is not None:
+            rec["id"] = node_id
+            rec["node_id"] = node_id
+        rec["x"] = raw.get("x", rec.get("x", 0))
+        rec["y"] = raw.get("y", rec.get("y", 0))
+        rec["warnings"] = _issue_list(raw.get("warnings", rec.get("warnings", [])))
+        rec["errors"] = _issue_list(raw.get("errors", rec.get("errors", [])))
+        if "userCode" in raw and "userCode" not in rec:
+            rec["userCode"] = raw.get("userCode")
+
+        fn_name = rec.get("functionName") or rec.get("function_name") or rec.get("name") or ""
+        if node_id is not None:
+            node_name_by_id[str(node_id)] = str(fn_name)
+        normalized_nodes.append(rec)
+
+    normalized_edges: list[dict] = []
+    for raw in edges:
+        if not isinstance(raw, dict):
+            continue
+        rec = dict(raw)
+        src_id = rec.get("source") or rec.get("source_id") or rec.get("from") or rec.get("sourceNode")
+        tgt_id = rec.get("target") or rec.get("target_id") or rec.get("to") or rec.get("targetNode")
+        if src_id is not None:
+            rec["source"] = src_id
+            rec.setdefault("source_function", node_name_by_id.get(str(src_id), str(src_id)))
+        if tgt_id is not None:
+            rec["target"] = tgt_id
+            rec.setdefault("target_function", node_name_by_id.get(str(tgt_id), str(tgt_id)))
+        normalized_edges.append(rec)
+
+    return normalized_nodes, normalized_edges
 
 
 def _coa_shape_debug(coa_data: dict) -> dict:
@@ -2465,7 +2534,13 @@ def tool_get_playbook_coa_summary(
     passed_validation = rest_data.get("passed_validation", coa_data.get("passed_validation", False))
     # VERIFY: playbook_type / trigger field names
     playbook_type = rest_data.get("playbook_type") or coa_data.get("playbook_type", "")
-    trigger = rest_data.get("trigger") or coa_data.get("trigger", "")
+    trigger = (
+        rest_data.get("playbook_trigger")
+        or rest_data.get("trigger")
+        or coa_data.get("playbook_trigger")
+        or coa_data.get("trigger")
+        or ""
+    )
 
     findings = []
     if warning_count:

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -1273,13 +1273,9 @@ def tool_list_case_notes(client: SoarApiClient, config: McpServerConfig, args: d
 def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: dict) -> str:
     """List available SOAR playbooks."""
     active_only = args.get("active_only", True)
-    category = args.get("category", "")
+    category = (args.get("category", "") or "").strip()
 
     params: dict = {"page_size": config.max_results}
-    if active_only:
-        params["_filter_active"] = "true"  # SOAR requires lowercase (bug #7)
-    if category:
-        params["_filter_category__icontains"] = f'"{category}"'
 
     data, err = client.get("playbook", params=params)
     if err:
@@ -1287,6 +1283,11 @@ def tool_list_playbooks(client: SoarApiClient, config: McpServerConfig, args: di
 
     items = data if isinstance(data, list) else data.get("data", [])
     total = data.get("count", len(items)) if isinstance(data, dict) else len(items)
+    if active_only:
+        items = [pb for pb in items if bool(pb.get("active"))]
+    if category:
+        cat = category.lower()
+        items = [pb for pb in items if cat in str(pb.get("category", "")).lower()]
     if not items:
         return "No playbooks found."
 

--- a/soar_mcp_view.py
+++ b/soar_mcp_view.py
@@ -99,9 +99,15 @@ def _build_record(data: dict, status: str, message: str, soar_base_url: str = ""
     if endpoint_from_data:
         mcp_endpoint = endpoint_from_data
     elif soar_base_url:
-        mcp_endpoint = f"{soar_base_url}/rest/handler/phantom_soar_mcp_server/mcp"
+        mcp_endpoint = (
+            f"{soar_base_url}/rest/handler/"
+            "soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/<asset_name>"
+        )
     else:
-        mcp_endpoint = "https://YOUR_SOAR_HOST/rest/handler/phantom_soar_mcp_server/mcp"
+        mcp_endpoint = (
+            "https://YOUR_SOAR_HOST/rest/handler/"
+            "soarmcpserver_ff5f68f3-353c-4d89-9767-967ef5d99117/<asset_name>"
+        )
 
     # Compute read vs write breakdown using known write tool names
     write_enabled_count = len([t for t in enabled_tools if t in _WRITE_TOOLS])

--- a/test_soar_mcp_config_asset_overrides.py
+++ b/test_soar_mcp_config_asset_overrides.py
@@ -1,0 +1,31 @@
+"""Regression coverage for SOAR asset-level MCP config overrides."""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from soar_mcp_config import McpConfigLoader
+
+
+class SoarMcpConfigAssetOverridesTest(unittest.TestCase):
+    def test_ssl_verify_asset_override_is_applied(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "default").mkdir()
+            (root / "local").mkdir()
+            (root / "default" / "mcp.conf").write_text(
+                "[server]\nssl_verify = true\n", encoding="utf-8"
+            )
+            (root / "local" / "asset_overrides.json").write_text(
+                json.dumps({"ssl_verify": False}), encoding="utf-8"
+            )
+
+            cfg = McpConfigLoader(root).load()
+
+        self.assertFalse(cfg.ssl_verify)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_handler_errors.py
+++ b/test_soar_mcp_handler_errors.py
@@ -1,0 +1,71 @@
+"""Regression coverage for MCP handler error and dry-run semantics."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_handler import SoarMcpRestHandler
+
+
+class _FakeClient:
+    pass
+
+
+class SoarMcpHandlerErrorsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = McpServerConfig()
+        self.client = _FakeClient()
+        self.handler = dict.__new__(SoarMcpRestHandler)
+
+    def test_handler_marks_error_text_as_mcp_error(self):
+        with patch("soar_mcp_handler.call_tool", return_value="Error: invalid input"):
+            result = self.handler._handle_tools_call(
+                {"name": "list_cases", "arguments": {}},
+                self.client,
+                self.cfg,
+                None,
+            )
+        self.assertTrue(result["isError"])
+
+        with patch("soar_mcp_handler.call_tool", return_value='{"ok": false, "errors": []}'):
+            result = self.handler._handle_tools_call(
+                {"name": "list_cases", "arguments": {}},
+                self.client,
+                self.cfg,
+                None,
+            )
+        self.assertTrue(result["isError"])
+
+    def test_handler_allows_disabled_layout_dry_run_preview_only(self):
+        self.assertNotIn("save_playbook_layout_only", self.cfg.enabled_tools)
+        with patch("soar_mcp_handler.call_tool", return_value='{"ok": true}'):
+            result = self.handler._handle_tools_call(
+                {
+                    "name": "save_playbook_layout_only",
+                    "arguments": {"playbook_id": 180, "node_positions": {"a": {"x": 1, "y": 2}}},
+                },
+                self.client,
+                self.cfg,
+                None,
+            )
+        self.assertFalse(result["isError"])
+
+        denied = self.handler._handle_tools_call(
+            {
+                "name": "save_playbook_layout_only",
+                "arguments": {
+                    "playbook_id": 180,
+                    "node_positions": {"a": {"x": 1, "y": 2}},
+                    "dry_run": False,
+                },
+            },
+            self.client,
+            self.cfg,
+            None,
+        )
+        self.assertTrue(denied["isError"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_soar85_coa_summary.py
+++ b/test_soar_mcp_soar85_coa_summary.py
@@ -1,0 +1,94 @@
+"""Regression coverage for SOAR 8.5 COA graph and summary behavior."""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import (
+    _get_coa_nodes_edges,
+    _resolve_current_id,
+    tool_get_playbook_coa_summary,
+)
+
+
+class _FakeCoaClient:
+    def __init__(self) -> None:
+        self.coa = {
+            "id": 180,
+            "current_id": 180,
+            "playbook_trigger": "artifact_created",
+            "coa_data": {
+                "nodes": {
+                    "0": {
+                        "id": "0",
+                        "x": 10,
+                        "y": 20,
+                        "data": {"type": "code", "functionName": "do_work"},
+                    }
+                },
+                "edges": [],
+            },
+        }
+
+    def get(self, path, params=None):
+        if path == "playbook/180":
+            return {
+                "id": 180,
+                "name": "Quarantine",
+                "version": 9,
+                "playbook_trigger": "artifact_created",
+                "passed_validation": True,
+            }, None
+        return {}, None
+
+    def _coa_get(self, path, params=None):
+        return self.coa, None
+
+    def get_binary(self, path, params=None):
+        return b"", None
+
+
+class _StaleCoaClient:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def _coa_get(self, path, params=None):
+        self.calls.append(path)
+        if path == "playbooks/172":
+            return {"id": 172, "current_id": 180, "coa_data": {"nodes": {"old": {}}}}, None
+        if path == "playbooks/180":
+            return {"id": 180, "current_id": 180, "coa_data": {"nodes": {"current": {}}}}, None
+        return {}, None
+
+
+class Soar85CoaSummaryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = McpServerConfig()
+        self.cfg.advisory_disclaimer = False
+
+    def test_coa_data_shape_is_normalized(self):
+        client = _FakeCoaClient()
+        nodes, edges = _get_coa_nodes_edges(client.coa)
+        self.assertEqual(len(nodes), 1)
+        self.assertEqual(len(edges), 0)
+        self.assertEqual(nodes[0]["functionName"], "do_work")
+        self.assertEqual(nodes[0]["x"], 10)
+
+    def test_resolve_current_id_refetches_current_payload(self):
+        client = _StaleCoaClient()
+        current_id, coa_data, err = _resolve_current_id(client, 172)
+        self.assertIsNone(err)
+        self.assertEqual(current_id, 180)
+        self.assertEqual(coa_data["id"], 180)
+        self.assertEqual(client.calls, ["playbooks/172", "playbooks/180"])
+
+    def test_coa_summary_reads_playbook_trigger(self):
+        client = _FakeCoaClient()
+        data = json.loads(tool_get_playbook_coa_summary(client, self.cfg, {"playbook_id": 180}))
+        self.assertEqual(data["data"]["trigger"], "artifact_created")
+        self.assertEqual(data["data"]["node_count"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_soar85_list_playbooks.py
+++ b/test_soar_mcp_soar85_list_playbooks.py
@@ -1,0 +1,41 @@
+"""Regression coverage for SOAR 8.5 playbook listing behavior."""
+from __future__ import annotations
+
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import tool_list_playbooks
+
+
+class _FakePlaybookClient:
+    def __init__(self) -> None:
+        self.get_calls: list[tuple[str, dict | None]] = []
+
+    def get(self, path, params=None):
+        self.get_calls.append((path, params))
+        if path == "playbook":
+            return {
+                "data": [
+                    {"id": 1, "name": "Active PB", "active": True, "category": "response"},
+                    {"id": 2, "name": "Inactive PB", "active": False, "category": "response"},
+                ],
+                "count": 2,
+            }, None
+        return {}, None
+
+
+class Soar85ListPlaybooksTest(unittest.TestCase):
+    def test_list_playbooks_filters_active_locally(self):
+        cfg = McpServerConfig()
+        cfg.advisory_disclaimer = False
+        client = _FakePlaybookClient()
+
+        out = tool_list_playbooks(client, cfg, {"active_only": True})
+
+        self.assertIn("Active PB", out)
+        self.assertNotIn("Inactive PB", out)
+        self.assertEqual(client.get_calls[0], ("playbook", {"page_size": 50}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_soar_mcp_soar85_validation_drift.py
+++ b/test_soar_mcp_soar85_validation_drift.py
@@ -1,0 +1,89 @@
+"""Regression coverage for SOAR 8.5 validation and Python drift checks."""
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import (
+    tool_check_saved_generated_python_drift,
+    tool_validate_playbook_bundle,
+)
+
+
+def _tar_with_python(source: str) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tarf:
+        payload = source.encode("utf-8")
+        info = tarfile.TarInfo("playbook.py")
+        info.size = len(payload)
+        tarf.addfile(info, io.BytesIO(payload))
+    return buf.getvalue()
+
+
+class _FakeValidationClient:
+    def __init__(self) -> None:
+        self.coa = {
+            "id": 180,
+            "current_id": 180,
+            "coa_data": {
+                "nodes": {
+                    "0": {
+                        "id": "0",
+                        "data": {"type": "code", "functionName": "do_work"},
+                    }
+                },
+                "edges": [],
+            },
+            "python": (
+                "def on_start(container):\n"
+                "    do_work(container)\n\n"
+                "def do_work(container):\n"
+                "    return None\n\n"
+                "def on_finish(container, summary):\n"
+                "    return None\n"
+            ),
+        }
+
+    def get(self, path, params=None):
+        if path == "playbook/180":
+            return {
+                "id": 180,
+                "name": "Quarantine",
+                "version": 9,
+                "passed_validation": True,
+            }, None
+        if path == "playbook/180/validate":
+            raise AssertionError("SOAR 8.5 validate endpoint must not be called")
+        return {}, None
+
+    def _coa_get(self, path, params=None):
+        return self.coa, None
+
+    def get_binary(self, path, params=None):
+        return _tar_with_python(self.coa["python"]), None
+
+
+class Soar85ValidationDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cfg = McpServerConfig()
+        self.cfg.advisory_disclaimer = False
+        self.client = _FakeValidationClient()
+
+    def test_validate_bundle_does_not_probe_validate_endpoint(self):
+        data = json.loads(tool_validate_playbook_bundle(self.client, self.cfg, {"playbook_id": 180}))
+        names = [c["name"] for c in data["data"]["checks"]]
+        self.assertNotIn("validate_structure", names)
+        self.assertEqual(data["ok"], True)
+
+    def test_drift_check_uses_coa_python_payload(self):
+        data = json.loads(tool_check_saved_generated_python_drift(self.client, self.cfg, {"playbook_id": 180}))
+        self.assertEqual(data["data"]["status"], "completed")
+        self.assertEqual(data["data"]["python_source"], "coa_python")
+        self.assertEqual(data["ok"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Document generated handler endpoint and expose SSL verification override

## Summary
- Add `ssl_verify` to asset-level configuration so self-signed lab instances can
  opt out explicitly.
- Persist and display the generated handler endpoint path that SOAR actually
  serves for this app.
- Update README guidance to describe the generated handler directory instead of a
  static handler path.

## Why
SOAR generates handler paths from the app name and UUID. A static path can send
users to a non-existent endpoint. Asset-level SSL verification is also needed for
LAN lab instances with self-signed certificates.

## Validation
```bash
python3 -m compileall -q .
python3 -m unittest test_soar_mcp_config_asset_overrides -v
```

## Local branch
`upstream/pr5-config-docs-endpoint`

## Stack note
This is part of a five-PR SOAR 8.5 compatibility series.
Preferred focused review base: `upstream/pr4-mcp-handler-error-dryrun`.
GitHub upstream PRs target `main` because this account does not have permission to create intermediate base branches in `abuis78/soar_mcp_server`.
