### PR TITLE
security: harden credential handling + uber_view widget (#39 #40 #52 #53 #55 #59)

### DIFF
--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -106,7 +106,9 @@ class SoarMcpConnector(BaseConnector):
                 resp = _req.get(
                     f"{self._base_url}/rest/asset/{asset_id}",
                     headers={"ph-auth-token": self._auth_token},
-                    verify=False,
+                    # Respect configured ssl_verify instead of hardcoding False.
+                    # Defaults to True (fail-secure) before asset overrides load.
+                    verify=get_config().ssl_verify,
                     timeout=10,
                 )
                 if resp.status_code == 200:
@@ -161,6 +163,10 @@ class SoarMcpConnector(BaseConnector):
         if self._base_url and self._asset_name:
             mcp_endpoint = build_mcp_endpoint(self._base_url, self._asset_name)
 
+        # Security: the SOAR auth_token is intentionally NOT persisted here.
+        # It is resolved per-request by the handler from the incoming header
+        # (soar_mcp_handler.py) and must never be written to disk in cleartext
+        # or rendered into a widget. Config-builder widgets show a placeholder.
         overrides = {
             "tools": tool_overrides,
             "ai_instructions": ai_instructions,
@@ -168,7 +174,6 @@ class SoarMcpConnector(BaseConnector):
             "ssl_verify": ssl_verify,
             "asset_name": self._asset_name,
             "base_url": self._base_url,
-            "auth_token": self._auth_token,
             "mcp_endpoint": mcp_endpoint,
         }
 
@@ -281,10 +286,12 @@ class SoarMcpConnector(BaseConnector):
         asset = self._asset_name or "<asset_name>"
         mcp_endpoint = build_mcp_endpoint(soar_host, asset)
 
-        # Include connection details so the widget can render copy-ready config
+        # Include connection details so the widget can render copy-ready config.
+        # Security: never include the real auth_token in the action result — it
+        # would be persisted in the SOAR DB and rendered into the widget. The
+        # widget uses a placeholder; the analyst pastes their own token.
         summary["mcp_endpoint"] = mcp_endpoint
         summary["base_url"] = self._base_url
-        summary["auth_token"] = self._auth_token
 
         action_result.add_data(summary)
         action_result.set_summary({

--- a/soar_mcp_uber_view.py
+++ b/soar_mcp_uber_view.py
@@ -4,6 +4,7 @@ SOAR MCP Server — Uber View (Case Widget)
 Copyright 2026 Andreas Buis
 """
 
+import html as _html
 import json
 import os
 import traceback as _tb
@@ -48,9 +49,6 @@ def display_uber_view(provides, all_app_runs, context):
             or _extract_asset_name_from_runs(all_app_runs)
             or _extract_asset_name_from_request(context)
         )
-        # Write debug info so we can see what SOAR passes
-        _write_provides_debug(provides, asset_name, context)
-
         # ── 4. Build endpoint — always fresh from soar_base + asset_name ──────
         # Never use the stored mcp_endpoint from overrides because the
         # connector may have written it before the base_url was known.
@@ -109,8 +107,11 @@ def display_uber_view(provides, all_app_runs, context):
                 "off":   ("background:#1a1c20;color:#444850;border:1px solid #2e3138;",),
             }
             st = colors[kind][0]
+            # HTML-escape the tool name — it is rendered via `| safe` in the
+            # template, so defend against any non-allowlisted value reaching here.
+            safe_t = _html.escape(str(t))
             return ('<span style="font-family:monospace;font-size:10px;padding:2px 7px;'
-                    'border-radius:3px;' + st + '">' + t + '</span>')
+                    'border-radius:3px;' + st + '">' + safe_t + '</span>')
 
         enabled_pills = " ".join(
             pill(t, "write" if t in _WRITE_TOOLS else "read")
@@ -147,10 +148,6 @@ def display_uber_view(provides, all_app_runs, context):
 
     except Exception:
         err = _tb.format_exc()
-        try:
-            open("/tmp/mcp_uber_err.txt", "w").write(err)
-        except Exception:
-            pass
         context.update({
             "error_html": (
                 '<div style="background:#1a0000;border:1px solid #600;border-radius:4px;'
@@ -169,28 +166,6 @@ def display_uber_view(provides, all_app_runs, context):
         })
 
     return "soar_mcp_uber_view.html"
-
-
-def _write_provides_debug(provides, resolved_name: str, context) -> None:
-    """Write debug info to /tmp so the asset_name source can be diagnosed."""
-    try:
-        req = context.get("request")
-        path = getattr(req, "path", "") if req else ""
-        meta_keys = sorted([k for k in (getattr(req, "META", {}) or {}) if any(
-            x in k for x in ("HOST", "PATH", "FORWARD", "USER", "ASSET"))]) if req else []
-        with open("/tmp/mcp_asset_debug.txt", "w") as f:
-            f.write(f"provides type: {type(provides)}\n")
-            f.write(f"provides repr: {repr(provides)}\n")
-            f.write(f"resolved asset_name: {resolved_name}\n")
-            f.write(f"request.path: {path}\n")
-            f.write(f"META keys (filtered): {meta_keys}\n")
-            # Try to show dir() of provides for unknown types
-            try:
-                f.write(f"provides dir: {[x for x in dir(provides) if not x.startswith('__')]}\n")
-            except Exception:
-                pass
-    except Exception:
-        pass
 
 
 def _extract_asset_name_from_runs(all_app_runs) -> str:
@@ -260,20 +235,15 @@ def _extract_asset_name_from_request(context) -> str:
 def _get_base_url(context):
     """
     Try every known method to get the SOAR base URL, in order of preference.
-    Writes debug info to /tmp/mcp_base_url_debug.txt on the first call.
     """
-    attempts = []
-
     # 1. SOAR's own helper (most reliable)
     try:
         import phantom.rest as _pr
         url = _pr.get_phantom_base_url()
         if url:
-            attempts.append(("phantom.rest", url))
-            _write_debug(attempts)
             return url.rstrip("/")
-    except Exception as e:
-        attempts.append(("phantom.rest", "err: " + str(e)))
+    except Exception:
+        pass
 
     req = context.get("request")
     if req:
@@ -281,11 +251,9 @@ def _get_base_url(context):
         try:
             url = req.build_absolute_uri("/").rstrip("/")
             if url and "YOUR_SOAR" not in url:
-                attempts.append(("build_absolute_uri", url))
-                _write_debug(attempts)
                 return url
-        except Exception as e:
-            attempts.append(("build_absolute_uri", "err: " + str(e)))
+        except Exception:
+            pass
 
         # 3. Forwarded host header (set by reverse proxy)
         try:
@@ -293,43 +261,20 @@ def _get_base_url(context):
             fwd = meta.get("HTTP_X_FORWARDED_HOST") or meta.get("HTTP_X_FORWARDED_SERVER")
             proto = meta.get("HTTP_X_FORWARDED_PROTO", "https")
             if fwd:
-                url = proto + "://" + fwd
-                attempts.append(("x-forwarded-host", url))
-                _write_debug(attempts)
-                return url
-        except Exception as e:
-            attempts.append(("x-forwarded-host", "err: " + str(e)))
+                return proto + "://" + fwd
+        except Exception:
+            pass
 
         # 4. Standard Django HOST header
         try:
             host = req.get_host()
             scheme = getattr(req, "scheme", "https")
-            url = scheme + "://" + host
             if host:
-                attempts.append(("get_host", url))
-                _write_debug(attempts)
-                return url
-        except Exception as e:
-            attempts.append(("get_host", "err: " + str(e)))
-
-        # 5. Dump META keys for debugging
-        try:
-            meta = getattr(req, "META", {})
-            attempts.append(("META_keys", str(sorted([k for k in meta if "HOST" in k or "SERVER" in k or "FORWARD" in k]))))
+                return scheme + "://" + host
         except Exception:
             pass
 
-    _write_debug(attempts)
     return ""
-
-
-def _write_debug(info):
-    try:
-        with open("/tmp/mcp_base_url_debug.txt", "w") as f:
-            for k, v in info:
-                f.write(k + ": " + str(v) + "\n")
-    except Exception:
-        pass
 
 
 def _read_asset_overrides() -> dict:

--- a/soar_mcp_uber_view.py
+++ b/soar_mcp_uber_view.py
@@ -64,14 +64,16 @@ def display_uber_view(provides, all_app_runs, context):
             endpoint = f"https://YOUR_SOAR_HOST/rest/handler/{_HANDLER_DIR}/YOUR_ASSET_NAME"
 
         # ── 5. Auth token ─────────────────────────────────────────────────────
-        auth_token = (
-            overrides.get("auth_token")
-            or data.get("auth_token")
-            or "YOUR_SOAR_AUTH_TOKEN"
-        )
+        # Security: NEVER render the live SOAR ph-auth-token into the widget.
+        # It is a full-access credential; embedding it in the DOM exposes it to
+        # anyone with widget access (screenshots, browser history, shoulder
+        # surfing). Always emit a placeholder — the analyst pastes their token.
+        auth_token = "YOUR_SOAR_AUTH_TOKEN"
 
         # ── 6. Has live data? ─────────────────────────────────────────────────
-        has_data = bool(soar_base and asset_name and auth_token != "YOUR_SOAR_AUTH_TOKEN")
+        # Endpoint is "live" once base_url + asset_name are known; the token is
+        # deliberately not part of this check anymore.
+        has_data = bool(soar_base and asset_name)
 
         enabled = list(data.get("enabled_tools", _DEFAULT_ENABLED))
         disabled = list(data.get("disabled_tools",


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_connector.py`, `soar_mcp_uber_view.py`
- **Scope:** `_get_asset_name`, `_write_asset_overrides`, `_handle_get_mcp_config`, `display_uber_view`, `_get_base_url`, `pill()`
- **Was ändert sich:** SOAR `auth_token` wird nicht mehr über ungeprüftes TLS gesendet, auf Disk geschrieben, in Action-Data abgelegt oder ins Widget gerendert; `/tmp`-Debug-Writer entfernt; Tool-Namen im Widget escaped.
- **Was bleibt unangetastet:** Tool-Logik, Token-Store, Endpoint-Aufbau, restliche Widget-Darstellung.

## Behobene Issues
| # | Fix |
|---|-----|
| #39 | `_get_asset_name`: `verify=get_config().ssl_verify` statt hartcodiertem `verify=False` |
| #40 | `auth_token` nicht mehr nach `asset_overrides.json` geschrieben |
| #53 | `get_mcp_config` legt `auth_token` nicht mehr in `action_result.data` ab |
| #52 | Uber-View rendert immer `YOUR_SOAR_AUTH_TOKEN`-Platzhalter |
| #55 | `/tmp`-Debug-Writer entfernt (Info-Disclosure) |
| #59 | Tool-Namen im `pill()` HTML-escaped |

## Verifikation
- `py_compile` alle Module: OK
- `unittest discover`: **29 Tests, OK**
- Grep: keine Live-`auth_token`- und keine `/tmp`-Referenzen mehr im Widget

Closes #39, closes #40, closes #52, closes #53, closes #55, closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)