### PR TITLE
standards+usability: manifest deps, contains-type, endpoint docs, server_version (#43 #47 #48 #60)

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -7,14 +7,15 @@
 #   <soar_app_dir>/soar_mcp_server/local/mcp.conf
 # and edit the local copy. Local values take precedence over defaults.
 #
-# The MCP endpoint is accessible at:
-#   https://<soar-host>/rest/handler/phantom_soar_mcp_server/mcp
+# The MCP endpoint is accessible at (read the exact URL from Test Connectivity
+# or the Get MCP Config action — the last path segment is your asset name):
+#   https://<soar-host>/rest/handler/soarmcpserver_<appid>/<asset_name>
 #
 # Connect Claude Desktop by adding to claude_desktop_config.json:
 #   {
 #     "mcpServers": {
 #       "splunk-soar": {
-#         "url": "https://<soar-host>/rest/handler/phantom_soar_mcp_server/mcp",
+#         "url": "https://<soar-host>/rest/handler/soarmcpserver_<appid>/<asset_name>",
 #         "headers": { "ph-auth-token": "<your-soar-auth-token>" }
 #       }
 #     }
@@ -25,7 +26,7 @@
 #     "mcpServers": {
 #       "splunk-soar": {
 #         "type": "http",
-#         "url": "https://<soar-host>/rest/handler/phantom_soar_mcp_server/mcp",
+#         "url": "https://<soar-host>/rest/handler/soarmcpserver_<appid>/<asset_name>",
 #         "headers": { "ph-auth-token": "<your-soar-auth-token>" }
 #       }
 #     }
@@ -63,8 +64,9 @@ protocol_version = 2024-11-05
 server_name = splunk-soar-mcp-server
 
 # Server version advertised to MCP clients.
-# Default: 1.0.0
-server_version = 1.0.0
+# Leave unset to report the app_version from the manifest (recommended).
+# Uncomment only to override with a custom value.
+# server_version = 1.0.0
 
 
 # ==============================================================================

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -20,6 +20,20 @@ from typing import Optional, Set, Union
 logger = logging.getLogger(__name__)
 
 _CONFIG_FILENAME = "mcp.conf"
+_MANIFEST_FILENAME = "soar_mcp_server.json"
+
+
+def _manifest_app_version() -> str:
+    """Return app_version from the manifest so the MCP server reports the real
+    version to clients instead of a hardcoded, drift-prone literal (issue #48)."""
+    try:
+        import json as _json
+        manifest = Path(__file__).parent / _MANIFEST_FILENAME
+        with open(manifest, encoding="utf-8") as fh:
+            return str(_json.load(fh).get("app_version") or "").strip() or "0.0.0"
+    except Exception:
+        return "0.0.0"
+
 
 # ── Valid values ───────────────────────────────────────────────────────────────
 _VALID_SEVERITIES = {"high", "medium", "low", "informational", ""}
@@ -118,7 +132,7 @@ class McpServerConfig:
     log_tool_calls: bool = True
     protocol_version: str = "2024-11-05"
     server_name: str = "splunk-soar-mcp-server"
-    server_version: str = "1.0.0"
+    server_version: str = field(default_factory=_manifest_app_version)
 
     # [tools] section — set of enabled tool names
     enabled_tools: Set[str] = field(default_factory=lambda: set(READ_ONLY_TOOLS))
@@ -233,7 +247,9 @@ class McpConfigLoader:
         config.log_tool_calls = self._get_bool(parser, "server", "log_tool_calls", True)
         config.protocol_version = parser.get("server", "protocol_version", fallback="2024-11-05").strip()
         config.server_name = parser.get("server", "server_name", fallback="splunk-soar-mcp-server").strip()
-        config.server_version = parser.get("server", "server_version", fallback="1.0.0").strip()
+        config.server_version = parser.get(
+            "server", "server_version", fallback=_manifest_app_version()
+        ).strip() or _manifest_app_version()
 
         # ── [tools] ───────────────────────────────────────────────────────────
         enabled: set[str] = set()

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -30,6 +30,9 @@
         "pypi": [
             {
                 "module": "requests"
+            },
+            {
+                "module": "cryptography"
             }
         ]
     },
@@ -435,6 +438,7 @@
                 "soar_user_id": {
                     "description": "SOAR user identifier the token acts on behalf of.",
                     "data_type": "string",
+                    "contains": ["soar mcp user id"],
                     "required": true,
                     "order": 1
                 },
@@ -461,7 +465,7 @@
             "output": [
                 {"data_path": "action_result.status", "data_type": "string", "column_name": "Status", "column_order": 0},
                 {"data_path": "action_result.message", "data_type": "string", "column_name": "Message", "column_order": 1},
-                {"data_path": "action_result.data.*.token_id", "data_type": "string", "column_name": "Token ID", "column_order": 2},
+                {"data_path": "action_result.data.*.token_id", "data_type": "string", "contains": ["soar mcp token id"], "column_name": "Token ID", "column_order": 2},
                 {"data_path": "action_result.data.*.raw_token", "data_type": "string", "column_name": "Raw Token (shown once)", "column_order": 3},
                 {"data_path": "action_result.data.*.expires_at", "data_type": "numeric", "column_name": "Expires", "column_order": 4},
                 {"data_path": "action_result.data.*.cursor_mcp_json_snippet", "data_type": "string", "column_name": "Cursor mcp.json", "column_order": 5}
@@ -485,9 +489,9 @@
             },
             "output": [
                 {"data_path": "action_result.status", "data_type": "string", "column_name": "Status", "column_order": 0},
-                {"data_path": "action_result.data.*.id", "data_type": "string", "column_name": "Token ID", "column_order": 1},
+                {"data_path": "action_result.data.*.id", "data_type": "string", "contains": ["soar mcp token id"], "column_name": "Token ID", "column_order": 1},
                 {"data_path": "action_result.data.*.label", "data_type": "string", "column_name": "Label", "column_order": 2},
-                {"data_path": "action_result.data.*.soar_user_id", "data_type": "string", "column_name": "Bound User", "column_order": 3},
+                {"data_path": "action_result.data.*.soar_user_id", "data_type": "string", "contains": ["soar mcp user id"], "column_name": "Bound User", "column_order": 3},
                 {"data_path": "action_result.data.*.last_used_at", "data_type": "numeric", "column_name": "Last Used", "column_order": 4},
                 {"data_path": "action_result.data.*.is_active", "data_type": "boolean", "column_name": "Active", "column_order": 5}
             ],
@@ -503,6 +507,7 @@
                 "token_id": {
                     "description": "Token ID to revoke (from 'list mcp tokens').",
                     "data_type": "string",
+                    "contains": ["soar mcp token id"],
                     "required": true,
                     "order": 0
                 }
@@ -510,7 +515,7 @@
             "output": [
                 {"data_path": "action_result.status", "data_type": "string", "column_name": "Status", "column_order": 0},
                 {"data_path": "action_result.message", "data_type": "string", "column_name": "Message", "column_order": 1},
-                {"data_path": "action_result.data.*.token_id", "data_type": "string", "column_name": "Token ID", "column_order": 2}
+                {"data_path": "action_result.data.*.token_id", "data_type": "string", "contains": ["soar mcp token id"], "column_name": "Token ID", "column_order": 2}
             ],
             "versions": "EQ(*)"
         }


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_server.json`, `default/mcp.conf`, `soar_mcp_config.py`
- **Scope:** `pip3_dependencies`, Token-Action-Felder, mcp.conf-Kommentare + server_version, `_manifest_app_version()`
- **Was ändert sich:** `cryptography` deklariert; `contains`-Typen für Token-IDs; korrekte Endpoint-Doku; `server_version` aus Manifest.
- **Was bleibt unangetastet:** Tool-Logik, Auth, Rückgabeformate.

## Behobene Issues
| # | Fix |
|---|-----|
| #43 | `cryptography` in `pip3_dependencies` → Fernet-Verschlüsselung statt stillem base64-Fallback |
| #60 | `contains`-Typen (`soar mcp token id` / `soar mcp user id`) → mint/list-Output verkettet in VPE mit revoke-Input |
| #47 | `default/mcp.conf` dokumentiert echten Endpoint `soarmcpserver_<appid>/<asset_name>` |
| #48 | `server_version` aus Manifest-`app_version` (1.7.0) statt hartcodiertem 1.0.0 |

## Verifikation
- `json.tool` Manifest: valide
- `py_compile`: OK
- `_manifest_app_version()` → **1.7.0**, `McpServerConfig().server_version` → **1.7.0**
- `unittest discover`: **29 Tests, OK**

## Hinweis
Die rein kosmetischen Widget-Fallbacks (`soar_mcp_view.py` "1.1.0", `soar_mcp_uber_view.py` "1.2.0") greifen nur ohne Live-Daten und wurden nicht angefasst; sobald Test Connectivity lief, kommt die echte Version aus der Config.

Closes #43, closes #47, closes #48, closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)