### PR TITLE
security: write tools off by default — read-only-by-default posture (#45)

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -125,22 +125,23 @@ get_action_schema = true
 # Export a playbook as a base64-encoded gzip TAR (blockly golden template)
 export_playbook = true
 
-# ── Playbook-build WRITE tools (enabled by default for playbook-builder) ──────
+# ── Playbook-build WRITE tools (OFF by default — enable for the builder) ──────
 
-# Import a generated playbook into SOAR so it is editable in the VPE
-import_playbook = true
+# Import a generated playbook into SOAR so it is editable in the VPE.
+# WRITE — off by default; enable for the playbook-builder workflow.
+import_playbook = false
 
 # Create an isolated test container (case) for playbook self-tests.
 # WRITE — requires BOTH this flag AND enable_test_harness = true in [safety].
-create_container = true
+create_container = false
 
-# ── Write tools (playbook-builder required — enabled by default) ──────────────
+# ── Write tools (playbook-builder — OFF by default, enable when needed) ───────
 
-# Run a playbook on a case. Required for playbook self-test.
-run_playbook = true
+# Run a playbook on a case. WRITE — off by default.
+run_playbook = false
 
-# Add a new artifact to a case. Required for playbook self-test.
-create_artifact = true
+# Add a new artifact to a case. WRITE — off by default.
+create_artifact = false
 
 # ── COA Visual Editor tools (v1.6.3+, read tools — enabled by default) ────────
 

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -149,14 +149,14 @@
         "tool_create_artifact": {
             "description": "WRITE \u26a0\ufe0f \u2014 create_artifact: Add a new artifact/IOC to a case. Required for playbook self-test.",
             "data_type": "boolean",
-            "default": true,
+            "default": false,
             "required": false,
             "order": 31
         },
         "tool_run_playbook": {
             "description": "WRITE \u26a0\ufe0f \u2014 run_playbook: Trigger a SOAR playbook on a case. Required for playbook self-test.",
             "data_type": "boolean",
-            "default": true,
+            "default": false,
             "required": false,
             "order": 32
         },
@@ -226,14 +226,14 @@
         "tool_import_playbook": {
             "description": "WRITE \u26a0\ufe0f \u2014 import_playbook: Import a base64-encoded gzip TAR playbook archive into SOAR so it appears and is editable in the VPE.",
             "data_type": "boolean",
-            "default": true,
+            "default": false,
             "required": false,
             "order": 60
         },
         "tool_create_container": {
             "description": "WRITE \u26a0\ufe0f \u2014 create_container: Create an isolated test container for playbook self-testing. Requires BOTH this checkbox AND enable_test_harness = true in [safety] of mcp.conf. Never enable on production.",
             "data_type": "boolean",
-            "default": true,
+            "default": false,
             "required": false,
             "order": 61
         },


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_server.json`, `default/mcp.conf`
- **Scope:** Defaults von `create_artifact`, `run_playbook`, `import_playbook`, `create_container`
- **Was ändert sich:** Defaults `true` → `false`; frischer Install ist echt read-only.
- **Was bleibt unangetastet:** Tool-Logik, alle READ-Tools (weiter an), analyst-facing Write-Tools (waren schon off).

## Behobenes Issue
#45 — Write-Tools waren per Default aktiv, im Widerspruch zu "Read-Only by Default". Jetzt konsistent: Manifest + mcp.conf + Connector-Default (READ_ONLY_TOOLS) alle read-only.

## Auswirkung (bewusst gewählt)
Der Playbook-Builder-Workflow braucht nach dem Update ein **bewusstes Aktivieren** der Write-Tools per Asset-Checkbox. `create_container` bleibt zusätzlich durch `enable_test_harness` gated.

## Verifikation
- Manifest valide; alle 4 Defaults = `false` verifiziert
- `unittest discover`: **29 Tests, OK**

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)