### PR TITLE
security: generic client error messages, detail server-side only (#57)

### DIFF
--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -247,7 +247,8 @@ class SoarMcpConnector(BaseConnector):
                 else:
                     self.save_progress(f"SOAR API returned HTTP {resp.status_code} — check base_url.")
             except Exception as exc:
-                self.save_progress(f"SOAR API check failed: {exc} — verifying config only.")
+                self.debug_print(f"[MCP] SOAR API check failed: {exc}")
+                self.save_progress("SOAR API check failed — verifying config only.")
 
         # Purge expired/revoked tokens older than 90 days (lazy housekeeping)
         purged = 0
@@ -257,7 +258,8 @@ class SoarMcpConnector(BaseConnector):
                 if purged:
                     self.save_progress(f"Purged {purged} expired/revoked MCP token(s).")
             except Exception as exc:
-                self.save_progress(f"Token purge skipped: {exc}")
+                self.debug_print(f"[MCP] Token purge skipped: {exc}")
+                self.save_progress("Token purge skipped.")
 
         action_result.add_data({
             "mcp_endpoint": mcp_endpoint,
@@ -348,7 +350,8 @@ class SoarMcpConnector(BaseConnector):
                 lifetime_days=lifetime_days,
             )
         except Exception as exc:
-            return action_result.set_status(phantom.APP_ERROR, f"Mint failed: {exc}")
+            self.debug_print(f"[MCP] Mint failed: {exc}")
+            return action_result.set_status(phantom.APP_ERROR, "Mint failed — see debug log for details.")
 
         endpoint = build_mcp_endpoint(self._base_url or "", self._asset_name or "")
         cursor_snippet = json.dumps({
@@ -386,7 +389,8 @@ class SoarMcpConnector(BaseConnector):
         try:
             tokens = TokenStore.default().list(include_revoked=include_revoked)
         except Exception as exc:
-            return action_result.set_status(phantom.APP_ERROR, f"List failed: {exc}")
+            self.debug_print(f"[MCP] List failed: {exc}")
+            return action_result.set_status(phantom.APP_ERROR, "List failed — see debug log for details.")
         for t in tokens:
             action_result.add_data({
                 "id": t.id, "label": t.label, "soar_user_id": t.soar_user_id,
@@ -410,7 +414,8 @@ class SoarMcpConnector(BaseConnector):
         try:
             ok = TokenStore.default().revoke(token_id)
         except Exception as exc:
-            return action_result.set_status(phantom.APP_ERROR, f"Revoke failed: {exc}")
+            self.debug_print(f"[MCP] Revoke failed: {exc}")
+            return action_result.set_status(phantom.APP_ERROR, "Revoke failed — see debug log for details.")
         if not ok:
             return action_result.set_status(
                 phantom.APP_ERROR, f"Token {token_id} not found or already revoked.")

--- a/soar_mcp_handler.py
+++ b/soar_mcp_handler.py
@@ -84,9 +84,10 @@ class SoarMcpRestHandler(dict):
         try:
             response = self._process(request, path_args or [])
         except Exception as exc:
+            # Detail is logged server-side only; never echoed to the client (#57).
             logger.exception("[SOAR MCP] Fatal error in __init__: %s", exc)
             response = self._error(None, _JSONRPC_INTERNAL_ERROR,
-                                   f"MCP handler error: {exc}")
+                                   "Internal MCP handler error.")
         self.update(response)
 
     # ── Request processing ─────────────────────────────────────────────────────
@@ -151,7 +152,8 @@ class SoarMcpRestHandler(dict):
         try:
             rpc = json.loads(body_bytes)
         except (json.JSONDecodeError, TypeError) as exc:
-            return self._error(None, _JSONRPC_PARSE_ERROR, f"Invalid JSON: {exc}")
+            logger.info("[SOAR MCP] JSON parse error: %s", exc)
+            return self._error(None, _JSONRPC_PARSE_ERROR, "Invalid JSON in request body.")
 
         if not isinstance(rpc, dict):
             return self._error(None, _JSONRPC_INVALID_REQUEST, "Request must be a JSON object")

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -145,7 +145,9 @@ class SoarApiClient:
             if resp.status_code == 404:
                 return None, "Resource not found (HTTP 404)."
             if resp.status_code >= 400:
-                return None, f"SOAR API error HTTP {resp.status_code}: {resp.text[:200]}"
+                # Do not echo the raw SOAR response body to the client (#57).
+                logger.info("[MCP] get_binary HTTP %s body=%s", resp.status_code, resp.text[:200])
+                return None, f"SOAR API error (HTTP {resp.status_code})."
             return resp.content, None
         except requests.exceptions.Timeout:
             return None, f"SOAR REST API timed out after {self._config.timeout}s"


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_handler.py`, `soar_mcp_connector.py`, `soar_mcp_tools.py`
- **Scope:** `__init__`-Catch, JSON-Parse-Catch, `get_binary` >=400, connector mint/list/revoke + API-Check + Purge
- **Was ändert sich:** Generische user-facing Fehlermeldungen; Details nur server-seitig via logger/debug_print.
- **Was bleibt unangetastet:** SOAR-eigene `message`-Felder in `_handle_response` (von import_playbook-Diagnostik genutzt), Tool-Logik.

## Behobenes Issue
#57 — mehrere Pfade echoten rohe Exception-Strings / Response-Bodies (interne Pfade/Hostnamen) an authentifizierte Clients bzw. Action-Results. Jetzt konsistent zum bereits vorhandenen generischen Dispatch-Catch.

## Verifikation
- `py_compile` alle Module: OK · `unittest discover`: **29 Tests, OK**
- Grep: keine client-seitigen `{exc}`/`resp.text`-Echos mehr (nur `debug_print`/`logger`)

## Hinweis
Der größere **strukturierte Fehler-Klassifikator (#70)** — `category`/`endpoint_category`/`suggested_next_step` über alle Request-Methoden — bleibt als eigenes Feature offen. Dieser PR liefert den sicherheitsrelevanten Kern (#57).

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)