### PR TITLE
security: mint-token ephemerality, robust redaction, out-of-band Fernet key (#54 #56)

### DIFF
--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -363,21 +363,27 @@ class SoarMcpConnector(BaseConnector):
             }
         }, indent=2)
 
+        # Security (issue #54): do NOT persist the raw token (or a shell export
+        # containing it) in action_result.data — data.* is stored in the SOAR DB
+        # and is queryable/retrievable long after mint, contradicting "shown
+        # once". The raw token is surfaced only in the (prominent, one-time)
+        # status message. The datapath keeps non-secret fields + an env-var
+        # config snippet.
         action_result.add_data({
             "token_id": minted.id,
             "label": minted.label,
-            "raw_token": minted.raw_token,           # shown ONCE
             "expires_at": minted.expires_at,
             "allowed_tools": minted.allowed_tools,
             "soar_user_id": minted.soar_user_id,
             "mcp_endpoint": endpoint,
             "cursor_mcp_json_snippet": cursor_snippet,
-            "shell_export_hint": f'export SOAR_MCP_TOKEN="{minted.raw_token}"',
         })
         action_result.set_summary({"token_id": minted.id, "label": minted.label})
         return action_result.set_status(
             phantom.APP_SUCCESS,
-            f"Minted MCP token {minted.id}. Copy now - the raw token is shown only this once.")
+            f"Minted MCP token {minted.id}. Copy the raw token now — it is shown only "
+            f"this once and is NOT stored:\n\n{minted.raw_token}\n\n"
+            f'Shell: export SOAR_MCP_TOKEN="{minted.raw_token}"')
 
     def _handle_list_mcp_tokens(self, param: dict) -> bool:
         action_result = self.add_action_result(ActionResult(dict(param)))

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -466,7 +466,6 @@
                 {"data_path": "action_result.status", "data_type": "string", "column_name": "Status", "column_order": 0},
                 {"data_path": "action_result.message", "data_type": "string", "column_name": "Message", "column_order": 1},
                 {"data_path": "action_result.data.*.token_id", "data_type": "string", "contains": ["soar mcp token id"], "column_name": "Token ID", "column_order": 2},
-                {"data_path": "action_result.data.*.raw_token", "data_type": "string", "column_name": "Raw Token (shown once)", "column_order": 3},
                 {"data_path": "action_result.data.*.expires_at", "data_type": "numeric", "column_name": "Expires", "column_order": 4},
                 {"data_path": "action_result.data.*.cursor_mcp_json_snippet", "data_type": "string", "column_name": "Cursor mcp.json", "column_order": 5}
             ],

--- a/soar_mcp_tokens.py
+++ b/soar_mcp_tokens.py
@@ -68,6 +68,18 @@ _TOKEN_PREFIX = "soarmcp_"
 _TOKEN_RAW_BYTES = 32  # 256 bits of entropy
 _STORE_VERSION = 1
 
+# Optional out-of-band Fernet key (issue #56). If this environment variable is
+# set, it is used for encrypt/decrypt in preference to the key stored in
+# mcp_tokens.json, so the key can live outside the data file (file-read access
+# then no longer equals plaintext access). Must be stable across the token
+# lifetime; if set after tokens were minted with a file key, decryption fails.
+_FERNET_KEY_ENV = "SOAR_MCP_FERNET_KEY"
+
+
+def _effective_key(file_key: str) -> str:
+    """Return the env-var Fernet key if configured, else the file-stored key."""
+    return os.environ.get(_FERNET_KEY_ENV) or file_key
+
 
 # ── Encryption helpers (Fernet) ────────────────────────────────────────────────
 
@@ -333,7 +345,7 @@ class TokenStore:
                 "soar_user_id": soar_user_id.strip()[:128],
                 "hash": _hash_token(raw, salt_hex),
                 "salt": salt_hex,
-                "encrypted_soar_token": _encrypt(soar_call_token, state.fernet_key),
+                "encrypted_soar_token": _encrypt(soar_call_token, _effective_key(state.fernet_key)),
                 "allowed_tools": allowed_tools_list,
                 "created_at": now,
                 "expires_at": expires_at,
@@ -395,7 +407,7 @@ class TokenStore:
                     pass
                 try:
                     call_token = _decrypt(entry.get("encrypted_soar_token", ""),
-                                          state.fernet_key)
+                                          _effective_key(state.fernet_key))
                 except Exception as exc:
                     logger.exception("[MCP tokens] decrypt failure: %s", exc)
                     return TokenVerification(valid=False, token_id=entry["id"],

--- a/soar_mcp_utils.py
+++ b/soar_mcp_utils.py
@@ -48,7 +48,9 @@ def redact_nested(obj: Any, *, depth: int = 0, max_depth: int = 10) -> Any:
     if isinstance(obj, dict):
         result: dict = {}
         for k, v in obj.items():
-            if isinstance(k, str) and k.lower() in _SENSITIVE_KEYS:
+            # Substring match (issue #54): catches raw_token, shell_export_hint,
+            # access_token, etc. — not just exact key names.
+            if isinstance(k, str) and any(s in k.lower() for s in _SENSITIVE_KEYS):
                 result[k] = _REDACTED
             else:
                 result[k] = redact_nested(v, depth=depth + 1, max_depth=max_depth)


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_connector.py`, `soar_mcp_utils.py`, `soar_mcp_tokens.py`, `soar_mcp_server.json`
- **Scope:** mint-Action-Output, `redact_nested`, Fernet-Key-Herkunft, Manifest mint-Output
- **Was ändert sich:** Rohtoken nicht mehr in `data.*`; Redaction per Substring; optionaler Env-Key.
- **Was bleibt unangetastet:** Token-Store-Format, verify/mint-Logik, restliche Actions.

## Behobene Issues
| # | Fix |
|---|-----|
| #54 | Rohtoken/shell_export_hint nicht mehr in `action_result.data` (DB-persistiert) — Token nur noch in der einmaligen Status-Message; `redact_nested` per Substring (raw_token/access_token werden jetzt redaktiert); manifest raw_token-Spalte entfernt |
| #56 | `SOAR_MCP_FERNET_KEY` Env-Var hat Vorrang vor dem Datei-Key → Key kann außerhalb von `mcp_tokens.json` liegen (File-Read ≠ Plaintext); Datei-Key bleibt Default-Fallback |

## Verifikation
- `py_compile` + Manifest valide
- `redact_nested`: raw_token/access_token → `<redacted>`, label bleibt
- `_effective_key`: Env-Var gewinnt, sonst Datei-Key
- `unittest discover`: **29 Tests, OK**

## Hinweis zu #56
Env-Key muss über die Token-Lebensdauer **stabil** sein; wird er nach dem Minten (mit Datei-Key) gesetzt, schlägt die Entschlüsselung fehl. Dokumentiert im Code.

Closes #54, closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)