### PR TITLE
feat: SOAR app package hygiene linter (#71)

### DIFF
--- a/scripts/lint_soar_app_package.py
+++ b/scripts/lint_soar_app_package.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+SOAR MCP Server — App Package Hygiene Linter (issue #71)
+
+Deterministic, offline checks for a SOAR app release archive (.tar/.tar.gz)
+BEFORE install or publication. Validates archive members WITHOUT extracting to
+disk, so it is safe to run against untrusted archives in CI.
+
+Usage:
+    python3 scripts/lint_soar_app_package.py <archive.tar[.gz]> [--json]
+
+Exit code: 0 if no blocking errors, 1 otherwise.
+
+Copyright 2026 Andreas Buis
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tarfile
+
+_TOP = "soar_mcp_server"
+
+# Files that must be present inside the top-level app directory.
+_REQUIRED_FILES = [
+    "soar_mcp_server.json",
+    "soar_mcp_connector.py",
+    "soar_mcp_handler.py",
+    "soar_mcp_config.py",
+    "soar_mcp_tools.py",
+]
+
+# Manifest fields that must be present and non-empty.
+_REQUIRED_MANIFEST_FIELDS = ["app_version", "main_module", "rest_handler", "appid"]
+
+# Directories that must NOT be shipped inside the app package.
+_EXCLUDED_PREFIXES = [f"{_TOP}/releases/", f"{_TOP}/local/", f"{_TOP}/.git/"]
+
+
+def _is_blocked_name(name: str) -> bool:
+    """macOS metadata / build artifacts that must never be in the archive."""
+    base = name.rstrip("/").split("/")[-1]
+    return (
+        base == ".DS_Store"
+        or base.startswith("._")
+        or "/__pycache__/" in f"/{name}"
+        or name.endswith(".pyc")
+    )
+
+
+def _unsafe_member(member: tarfile.TarInfo) -> str | None:
+    """Return a reason string if the member is path-unsafe, else None."""
+    name = member.name
+    if name.startswith("/"):
+        return "absolute path"
+    parts = name.split("/")
+    if ".." in parts:
+        return "path traversal (..)"
+    if member.issym() or member.islnk():
+        return "symlink/hardlink"
+    return None
+
+
+def lint_archive(path: str) -> dict:
+    """Return a report dict with `errors` (blocking) and `warnings` lists."""
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    try:
+        tarf = tarfile.open(path, mode="r:*")
+    except FileNotFoundError:
+        return {"ok": False, "errors": [f"archive not found: {path}"], "warnings": []}
+    except tarfile.TarError as exc:
+        return {"ok": False, "errors": [f"not a readable tar archive: {exc}"], "warnings": []}
+
+    with tarf:
+        members = tarf.getmembers()
+        names = [m.name for m in members]
+
+        if not members:
+            errors.append("archive is empty")
+
+        # Top-level directory entry must be present (the v1.6.9 install bug).
+        if f"{_TOP}/" not in names and _TOP not in names:
+            errors.append(
+                f"missing top-level directory entry '{_TOP}/' "
+                "(pack from the parent dir: tar -czf app.tar soar_mcp_server/)"
+            )
+
+        # Every member must live under the top-level app directory.
+        for name in names:
+            top = name.split("/")[0]
+            if top != _TOP:
+                errors.append(f"member outside '{_TOP}/': {name}")
+
+        # Path-safety, blocked files, excluded dirs.
+        for m in members:
+            reason = _unsafe_member(m)
+            if reason:
+                errors.append(f"unsafe member ({reason}): {m.name}")
+            if _is_blocked_name(m.name):
+                errors.append(f"blocked file in package: {m.name}")
+            if any(m.name.startswith(p) for p in _EXCLUDED_PREFIXES):
+                errors.append(f"release/local artifact must be excluded: {m.name}")
+
+        # Required files present.
+        member_set = set(names)
+        for rel in _REQUIRED_FILES:
+            if f"{_TOP}/{rel}" not in member_set:
+                errors.append(f"required file missing: {_TOP}/{rel}")
+
+        # Manifest validity.
+        manifest_name = f"{_TOP}/soar_mcp_server.json"
+        if manifest_name in member_set:
+            try:
+                fobj = tarf.extractfile(manifest_name)
+                manifest = json.loads(fobj.read().decode("utf-8")) if fobj else {}
+                for field in _REQUIRED_MANIFEST_FIELDS:
+                    if not manifest.get(field):
+                        errors.append(f"manifest field missing/empty: {field}")
+            except Exception as exc:
+                errors.append(f"manifest is not valid JSON: {exc}")
+
+    return {"ok": not errors, "errors": errors, "warnings": warnings}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Lint a SOAR app release archive.")
+    parser.add_argument("archive", help="Path to the .tar/.tar.gz app package")
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text")
+    args = parser.parse_args(argv)
+
+    report = lint_archive(args.archive)
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        if report["ok"]:
+            print(f"OK — {args.archive} passed all package hygiene checks.")
+        else:
+            print(f"FAILED — {args.archive} has {len(report['errors'])} blocking error(s):")
+            for e in report["errors"]:
+                print(f"  ✗ {e}")
+        for w in report["warnings"]:
+            print(f"  ! {w}")
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_lint_soar_app_package.py
+++ b/test_lint_soar_app_package.py
@@ -1,0 +1,116 @@
+"""Tests for the SOAR app package hygiene linter (issue #71)."""
+from __future__ import annotations
+
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+
+from scripts.lint_soar_app_package import lint_archive
+
+_TOP = "soar_mcp_server"
+_REQUIRED = [
+    "soar_mcp_server.json",
+    "soar_mcp_connector.py",
+    "soar_mcp_handler.py",
+    "soar_mcp_config.py",
+    "soar_mcp_tools.py",
+]
+_GOOD_MANIFEST = json.dumps({
+    "appid": "ff5f68f3", "app_version": "1.8.0",
+    "main_module": "soar_mcp_connector.py", "rest_handler": "soar_mcp_handler.X",
+}).encode()
+
+
+def _build(members: dict[str, bytes], *, add_topdir: bool = True,
+           extra: list[tarfile.TarInfo] | None = None) -> str:
+    """Write a tar.gz to a temp file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".tar.gz")
+    os.close(fd)
+    with tarfile.open(path, "w:gz") as tf:
+        if add_topdir:
+            d = tarfile.TarInfo(f"{_TOP}/")
+            d.type = tarfile.DIRTYPE
+            tf.addfile(d)
+        for name, data in members.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+        for info in (extra or []):
+            tf.addfile(info)
+    return path
+
+
+def _clean_members() -> dict[str, bytes]:
+    m = {f"{_TOP}/{f}": (b"x" if not f.endswith(".json") else _GOOD_MANIFEST)
+         for f in _REQUIRED}
+    return m
+
+
+class PackageLinterTest(unittest.TestCase):
+    def tearDown(self):
+        for p in getattr(self, "_paths", []):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+    def _lint(self, members, **kw):
+        path = _build(members, **kw)
+        self._paths = getattr(self, "_paths", []) + [path]
+        return lint_archive(path)
+
+    def test_clean_package_passes(self):
+        r = self._lint(_clean_members())
+        self.assertTrue(r["ok"], r["errors"])
+
+    def test_ds_store_blocked(self):
+        m = _clean_members()
+        m[f"{_TOP}/.DS_Store"] = b"junk"
+        r = self._lint(m)
+        self.assertFalse(r["ok"])
+        self.assertTrue(any(".DS_Store" in e for e in r["errors"]))
+
+    def test_apple_dotbar_blocked(self):
+        m = _clean_members()
+        m[f"{_TOP}/._soar_mcp_tools.py"] = b"junk"
+        r = self._lint(m)
+        self.assertFalse(r["ok"])
+
+    def test_missing_topdir_flagged(self):
+        r = self._lint(_clean_members(), add_topdir=False)
+        self.assertFalse(r["ok"])
+        self.assertTrue(any("top-level directory" in e for e in r["errors"]))
+
+    def test_missing_manifest_flagged(self):
+        m = _clean_members()
+        del m[f"{_TOP}/soar_mcp_server.json"]
+        r = self._lint(m)
+        self.assertFalse(r["ok"])
+        self.assertTrue(any("soar_mcp_server.json" in e for e in r["errors"]))
+
+    def test_invalid_manifest_json_flagged(self):
+        m = _clean_members()
+        m[f"{_TOP}/soar_mcp_server.json"] = b"{not valid json"
+        r = self._lint(m)
+        self.assertFalse(r["ok"])
+
+    def test_releases_artifact_excluded(self):
+        m = _clean_members()
+        m[f"{_TOP}/releases/app_v1.tar"] = b"x"
+        r = self._lint(m)
+        self.assertFalse(r["ok"])
+        self.assertTrue(any("release/local artifact" in e for e in r["errors"]))
+
+    def test_path_traversal_blocked(self):
+        extra = tarfile.TarInfo(f"{_TOP}/../evil.py")
+        extra.size = 0
+        r = self._lint(_clean_members(), extra=[extra])
+        self.assertFalse(r["ok"])
+        self.assertTrue(any("traversal" in e for e in r["errors"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `scripts/lint_soar_app_package.py` (neu), `test_lint_soar_app_package.py` (neu)
- **Scope:** eigenständiges Lint-Script + Tests — **kein** App-Runtime-Bezug
- **Was ändert sich:** neuer CI-tauglicher Package-Linter
- **Was bleibt unangetastet:** gesamte App-Logik

## Behobenes Issue — #71 (Phase 0)
Deterministische Offline-Checks fürs Release-Archiv **ohne Entpacken**: Top-Level-Dir, keine `.DS_Store`/`._*`/`__pycache__`/`*.pyc`, kein `releases/`/`local/`, valides Manifest + Pflichtfelder, Pflichtdateien, Pfad-Sicherheit (Traversal/absolut/Symlink).

## Verifikation
- `py_compile`: OK · `unittest discover`: **37 Tests, OK** (29 alt + 8 neu)
- **Sofort-Fund:** gegen `releases/soar_mcp_server_v1.7.2.tar` meldet der Linter 24 `._*`/`.DS_Store`-Verstöße → Release-Builds sollten `COPYFILE_DISABLE=1` setzen (wird ab v1.8.0 gemacht).

## Empfehlung
Als `pre-release`-Gate in den Build-Flow hängen (`python3 scripts/lint_soar_app_package.py <tar>` vor `gh release create`).

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)