### PR TITLE
feat: read-only generate_mcp_client_config tool (#72)

### DIFF
--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -80,6 +80,8 @@ ALL_TOOLS: list[str] = [
     "check_visual_editor_compat",
     # Write tools (v1.6.3+)
     "save_playbook_layout_only",
+    # Client config helper (v1.8.0+)
+    "generate_mcp_client_config",
 ]
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(
@@ -112,6 +114,8 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "verify_layout_only_change",
         "validate_playbook_bundle",
         "check_visual_editor_compat",
+        # Client config helper (v1.8.0+)
+        "generate_mcp_client_config",
     ]
 )
 

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -327,6 +327,13 @@
             "default": false,
             "required": false,
             "order": 91
+        },
+        "tool_generate_mcp_client_config": {
+            "description": "READ \u2014 generate_mcp_client_config: Generate copy-ready MCP client config snippets (Claude Desktop/Code, Cursor, CLI). Token values are always placeholders, never the real auth token.",
+            "data_type": "boolean",
+            "default": true,
+            "required": false,
+            "order": 81
         }
     },
     "actions": [

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -3790,6 +3790,65 @@ def tool_save_playbook_layout_only(
 # Dispatcher
 # ==============================================================================
 
+def tool_generate_mcp_client_config(
+    client: SoarApiClient, config: McpServerConfig, args: dict
+) -> str:
+    """Generate copy-safe MCP client config snippets (issue #72).
+
+    Read-only. Uses the real handler endpoint but ALWAYS a placeholder token —
+    never the configured asset auth_token (that would leak a credential).
+    """
+    import json as _json
+
+    endpoint = (
+        config.mcp_endpoint
+        or f"{client._base_url}/rest/handler/<soarmcpserver_appid>/<asset_name>"
+    )
+    ph = "YOUR_SOAR_AUTH_TOKEN"        # placeholder — never a real token
+    env = "${env:SOAR_MCP_TOKEN}"      # env-var reference for Cursor/shell setups
+
+    claude_desktop = {"mcpServers": {"splunk-soar": {
+        "url": endpoint, "headers": {"ph-auth-token": ph}}}}
+    claude_code = {"mcpServers": {"splunk-soar": {
+        "type": "http", "url": endpoint, "headers": {"ph-auth-token": ph}}}}
+    cursor = {"mcpServers": {"splunk-soar": {
+        "url": endpoint, "headers": {"ph-auth-token": env}}}}
+    cli = (f'claude mcp add --transport http splunk-soar "{endpoint}" '
+           f'-H "ph-auth-token: {ph}"')
+
+    lines = [
+        "MCP client configuration (replace the placeholder token with your own):",
+        "",
+        "# Claude Desktop — claude_desktop_config.json",
+        _json.dumps(claude_desktop, indent=2),
+        "",
+        "# Claude Code — ~/.claude.json",
+        _json.dumps(claude_code, indent=2),
+        "",
+        "# Claude Code CLI",
+        cli,
+        "",
+        "# Cursor — ~/.cursor/mcp.json (token via env var; run: "
+        'export SOAR_MCP_TOKEN="<your-token>")',
+        _json.dumps(cursor, indent=2),
+        "",
+        "Troubleshooting: 404 → check the handler path segment is your asset name; "
+        "401 → token invalid; SSL error → self-signed cert (set ssl_verify=false only "
+        "for test instances).",
+    ]
+    return "\n".join(lines)
+
+
+TOOL_SCHEMAS["generate_mcp_client_config"] = {
+    "description": (
+        "Generate copy-ready MCP client configuration snippets (Claude Desktop, "
+        "Claude Code, Cursor, CLI) for this SOAR MCP endpoint. Read-only. Token "
+        "values are always placeholders — never the real auth token."
+    ),
+    "inputSchema": {"type": "object", "properties": {}},
+}
+
+
 _TOOL_HANDLERS = {
     "list_cases": tool_list_cases,
     "get_case": tool_get_case,
@@ -3831,6 +3890,8 @@ _TOOL_HANDLERS = {
     "check_visual_editor_compat": tool_check_visual_editor_compat,
     # Write tools (v1.6.3+)
     "save_playbook_layout_only": tool_save_playbook_layout_only,
+    # Client config helper (v1.8.0+)
+    "generate_mcp_client_config": tool_generate_mcp_client_config,
 }
 
 


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_tools.py`, `soar_mcp_config.py`, `soar_mcp_server.json`
- **Scope:** neues read-only Tool `generate_mcp_client_config` + Registrierung + Checkbox
- **Was bleibt unangetastet:** bestehende Tools, Auth, Formate

## Behobenes Issue — #72 (Phase 0)
Copy-fertige MCP-Client-Snippets (Claude Desktop/Code, Cursor, CLI) mit echtem Endpoint, **immer Platzhalter-Token**.

## Verifikation
- `py_compile` + Manifest valide
- Smoke-Test: konfigurierter Token `SECRET-TOKEN-123` erscheint **nicht** im Output; `YOUR_SOAR_AUTH_TOKEN` + Endpoint vorhanden
- `unittest discover`: **37 Tests, OK**

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)