### PR TITLE
feat: gated delete_container for test cleanup (#66)

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -135,6 +135,11 @@ import_playbook = false
 # WRITE — requires BOTH this flag AND enable_test_harness = true in [safety].
 create_container = false
 
+# Delete a test container to clean up after self-tests.
+# WRITE — requires the test harness enabled; refuses non-'test' containers
+# unless confirm=true. Never enable on production.
+delete_container = false
+
 # ── Write tools (playbook-builder — OFF by default, enable when needed) ───────
 
 # Run a playbook on a case. WRITE — off by default.

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -66,6 +66,7 @@ ALL_TOOLS: list[str] = [
     "export_playbook",
     "import_playbook",
     "create_container",
+    "delete_container",
     # COA Visual Editor tools (v1.6.3+)
     "resolve_playbook_current_id",
     "get_playbook_identity_map",

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -237,6 +237,13 @@
             "required": false,
             "order": 61
         },
+        "tool_delete_container": {
+            "description": "WRITE \u26a0\ufe0f \u2014 delete_container: Delete a test container to clean up after self-tests. Requires the test harness enabled; refuses non-'test' containers unless confirm=true. Never enable on production.",
+            "data_type": "boolean",
+            "default": false,
+            "required": false,
+            "order": 62
+        },
         "tool_resolve_playbook_current_id": {
             "description": "READ \u2014 resolve_playbook_current_id: Resolve any playbook ID (current or stale) to the current Visual Editor draft. Foundation tool for all COA-based operations.",
             "data_type": "boolean",

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -147,6 +147,19 @@ class SoarApiClient:
         except Exception as e:
             return None, f"Unexpected error: {type(e).__name__}"
 
+    def delete(self, path: str) -> tuple[dict | None, str | None]:
+        """DELETE request. Returns (data, error_message)."""
+        url = f"{self._base_url}/rest/{path.lstrip('/')}"
+        try:
+            resp = self._session.delete(url, timeout=self._config.timeout)
+            return self._handle_response(resp)
+        except requests.exceptions.Timeout:
+            return None, f"SOAR REST API timed out after {self._config.timeout}s"
+        except requests.exceptions.ConnectionError as e:
+            return None, f"Connection error: {e}"
+        except Exception as e:
+            return None, f"Unexpected error: {type(e).__name__}"
+
     def get_binary(self, path: str, params: dict | None = None) -> tuple[bytes | None, str | None]:
         """GET request returning raw bytes (for binary endpoints like playbook export)."""
         url = f"{self._base_url}/rest/{path.lstrip('/')}"
@@ -1757,6 +1770,45 @@ def tool_create_container(client: SoarApiClient, config: McpServerConfig, args: 
         f"  Container ID: {container_id}\n"
         f"  Name: {name}\n"
         f"  Label: {label} | Severity: {severity}"
+    ) + (_disclaimer() if config.advisory_disclaimer else "")
+
+
+def tool_delete_container(client: SoarApiClient, config: McpServerConfig, args: dict) -> str:
+    """Delete a test container — closes the create→test→cleanup loop (issue #66)."""
+    # Same double gate as create_container: never allow deletion unless the test
+    # harness is explicitly enabled, so real production cases can't be removed.
+    if not getattr(config, "enable_test_harness", False):
+        return (
+            "Error: delete_container requires the test harness to be enabled. "
+            "Enable it via the 'enable_test_harness' checkbox in the asset "
+            "configuration (Apps → SOAR MCP Server → Asset Settings) and run "
+            "Test Connectivity. Never enable on a production SOAR instance."
+        )
+
+    container_id, err_msg = _require_positive_int(args.get("container_id"), "container_id")
+    if err_msg:
+        return err_msg
+
+    # Safety: refuse to delete a container that is not a recognisable test
+    # container unless the caller explicitly forces it. create_container writes
+    # a "test" label by default; require confirm=true to delete anything else.
+    confirm = bool(args.get("confirm", False))
+    existing, _ = client.get(f"container/{container_id}")
+    if isinstance(existing, dict):
+        label = (existing.get("label") or "").lower()
+        if label != "test" and not confirm:
+            return (
+                f"Refusing to delete container #{container_id}: its label is "
+                f"'{existing.get('label') or 'none'}', not 'test'. This does not look "
+                "like an MCP test container. Re-call with confirm=true if you are sure."
+            )
+
+    data, err = client.delete(f"container/{container_id}")
+    if err:
+        return f"Error deleting container {container_id}: {err}"
+
+    return (
+        f"✅ Test container #{container_id} deleted."
     ) + (_disclaimer() if config.advisory_disclaimer else "")
 
 
@@ -3848,6 +3900,22 @@ TOOL_SCHEMAS["generate_mcp_client_config"] = {
     "inputSchema": {"type": "object", "properties": {}},
 }
 
+TOOL_SCHEMAS["delete_container"] = {
+    "description": (
+        "WRITE — Delete a test container by ID to clean up after playbook self-tests. "
+        "Requires the test harness to be enabled. Refuses to delete containers not "
+        "labelled 'test' unless confirm=true. Never use on production."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "container_id": {"type": "integer", "description": "The test container/case ID to delete."},
+            "confirm": {"type": "boolean", "description": "Delete even if the label is not 'test' (default false).", "default": False},
+        },
+        "required": ["container_id"],
+    },
+}
+
 
 _TOOL_HANDLERS = {
     "list_cases": tool_list_cases,
@@ -3892,6 +3960,8 @@ _TOOL_HANDLERS = {
     "save_playbook_layout_only": tool_save_playbook_layout_only,
     # Client config helper (v1.8.0+)
     "generate_mcp_client_config": tool_generate_mcp_client_config,
+    # Test-harness cleanup (v1.8.0+)
+    "delete_container": tool_delete_container,
 }
 
 


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_tools.py`, `soar_mcp_config.py`, `soar_mcp_server.json`, `default/mcp.conf`
- **Scope:** `SoarApiClient.delete` (neu), `tool_delete_container` (neu), Registrierung + Checkbox
- **Was bleibt unangetastet:** bestehende Tools, create_container

## Behobenes Issue — #66 (Phase 0)
Gated `delete_container` hinter demselben `enable_test_harness`-Gate wie create_container; schließt den create→test→cleanup-Loop.

## Sicherheit
- Doppel-Gate (Harness-Flag) — bei off harte Ablehnung
- `container_id` als positive int validiert (Path-Traversal-Schutz)
- Verweigert Container ohne Label `test`, außer `confirm=true` — schützt echte Cases
- WRITE-Tool, **Default off**

## Verifikation
- `py_compile` + Manifest valide
- Smoke-Test: Harness off → Ablehnung; `container_id=-1` → Validierungsfehler
- `unittest discover`: **37 Tests, OK**

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)