### PR TITLE
feat: optional two-step confirmation gate for write tools (#50)

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -236,6 +236,12 @@ min_severity =
 # is enabled. Set to true ONLY on dev/test SOAR instances — never on production.
 enable_test_harness = false
 
+# Two-step commit for write tools (issue #50). When true, every write tool must
+# be called twice: the first call returns a confirm_token + preview, the second
+# (same args + token) executes. Enforces human-in-the-loop for AI-driven writes.
+# Default: false (backwards-compatible).
+require_confirmation = false
+
 [tokens]
 # Scoped MCP token settings (v1.5.0+).
 #

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -149,6 +149,10 @@ class McpServerConfig:
     min_severity: str = ""
     # Extra gate for create_container — prevents accidental case creation in production
     enable_test_harness: bool = False
+    # Two-step commit for write tools (issue #50). When true, write tools must be
+    # called twice: the first call returns a confirm_token, the second (with the
+    # same args + token) executes. Default off = backwards-compatible.
+    require_confirmation: bool = False
 
     # AI instructions — sent to the LLM in every MCP initialize response
     ai_instructions: str = ""
@@ -273,6 +277,7 @@ class McpConfigLoader:
         raw_sev = parser.get("safety", "min_severity", fallback="").strip().lower()
         config.min_severity = raw_sev if raw_sev in _VALID_SEVERITIES else ""
         config.enable_test_harness = self._get_bool(parser, "safety", "enable_test_harness", False)
+        config.require_confirmation = self._get_bool(parser, "safety", "require_confirmation", False)
 
         # ── [server] ai_instructions ───────────────────────────────────────────
         config.ai_instructions = parser.get("server", "ai_instructions", fallback="").strip()

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -20,15 +20,19 @@ Copyright 2026 Andreas Buis
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
+import secrets
 import textwrap
+import threading
+import time
 from typing import Any, Optional
 
 import requests
 
-from soar_mcp_config import McpServerConfig
+from soar_mcp_config import READ_ONLY_TOOLS, McpServerConfig
 
 # ── Security constants ─────────────────────────────────────────────────────────
 _MAX_NOTE_LENGTH = 10_000   # characters — prevents storage exhaustion (issue #11)
@@ -3965,6 +3969,81 @@ _TOOL_HANDLERS = {
 }
 
 
+# ── Write-tool confirmation gate (issue #50) ──────────────────────────────────
+# Write tools are those with a handler that are not read-only.
+_WRITE_TOOLS: frozenset[str] = frozenset(_TOOL_HANDLERS) - READ_ONLY_TOOLS
+
+
+class _ConfirmStore:
+    """In-process, TTL-bound confirmation tokens keyed on (tool, args).
+
+    Per-process only (like the token rate limiter); a confirm token issued on
+    one worker is not valid on another. That is acceptable — worst case the
+    client is asked to confirm again.
+    """
+
+    def __init__(self) -> None:
+        self._d: dict[str, tuple[str, float]] = {}
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _key(tool: str, args: dict) -> str:
+        blob = tool + "|" + json.dumps(args, sort_keys=True, default=str)
+        return hashlib.sha256(blob.encode()).hexdigest()
+
+    def issue(self, tool: str, args: dict, ttl: float = 300.0) -> str:
+        token = "confirm_" + secrets.token_urlsafe(9)
+        with self._lock:
+            self._d[token] = (self._key(tool, args), time.time() + ttl)
+        return token
+
+    def consume(self, token: str, tool: str, args: dict) -> bool:
+        with self._lock:
+            entry = self._d.get(token)
+            if not entry:
+                return False
+            key, exp = entry
+            if time.time() > exp or key != self._key(tool, args):
+                self._d.pop(token, None)
+                return False
+            self._d.pop(token, None)
+            return True
+
+
+_confirm_store = _ConfirmStore()
+
+
+def _maybe_require_confirmation(
+    tool_name: str, arguments: dict, config: McpServerConfig
+) -> Optional[str]:
+    """Return a confirmation-preview string if the call must be confirmed first,
+    or None to proceed. Two-step commit for write tools when
+    require_confirmation is enabled (issue #50)."""
+    if not getattr(config, "require_confirmation", False):
+        return None
+    if tool_name not in _WRITE_TOOLS:
+        return None
+    # Layout dry-run preview is read-only and safe — no confirmation needed.
+    if tool_name == "save_playbook_layout_only" and arguments.get("dry_run", True):
+        return None
+
+    key_args = {k: v for k, v in arguments.items() if k != "confirm_token"}
+    provided = arguments.get("confirm_token")
+    if provided and _confirm_store.consume(str(provided), tool_name, key_args):
+        return None  # confirmed — proceed
+
+    token = _confirm_store.issue(tool_name, key_args)
+    return (
+        "⚠️ Confirmation required — this SOAR MCP instance has require_confirmation "
+        "enabled for write operations.\n"
+        f"  Tool:      {tool_name}\n"
+        f"  Arguments: {json.dumps(key_args, default=str)[:400]}\n\n"
+        f"To execute, call {tool_name} again with the SAME arguments plus:\n"
+        f'  confirm_token = "{token}"\n'
+        "The token is valid for 5 minutes and only for these exact arguments."
+    )
+
+
 def call_tool(
     tool_name: str,
     arguments: dict,
@@ -3980,6 +4059,9 @@ def call_tool(
     handler = _TOOL_HANDLERS.get(tool_name)
     if handler is None:
         return f"Unknown tool: '{tool_name}'"
+    gate = _maybe_require_confirmation(tool_name, arguments or {}, config)
+    if gate is not None:
+        return gate
     try:
         result = handler(client, config, arguments or {})
         if config.log_tool_calls:


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_tools.py`, `soar_mcp_config.py`, `default/mcp.conf`
- **Scope:** `_ConfirmStore`/`_maybe_require_confirmation` (neu), `call_tool`, `require_confirmation`-Config
- **Was bleibt unangetastet:** einzelne Tool-Implementierungen (zentral in call_tool gated), Default-Verhalten

## Behobenes Issue — #50 (Phase 0)
Optionales `[safety] require_confirmation` (Default off). Bei aktiv: Write-Tools brauchen Zwei-Stufen-Commit (1. Call → confirm_token + Vorschau, 2. Call mit gleichen args + Token → Ausführung).

## Sicherheit / Design
- Token TTL-gebunden (5 min), **Single-Use**, an exakte (tool, args) gebunden
- Zentral in `call_tool` — keine per-Tool-Duplizierung
- Layout-Dry-Run-Preview ausgenommen (read-like)
- Default off → rückwärtskompatibel; ergänzt die write-off-by-default-Posture um technische Durchsetzung

## Verifikation
- `py_compile`: OK
- Smoke-Test: 1. Call gated → Token; 2. Call mit Token → Ausführung; Reuse → erneut gated; Flag off → kein Gate
- `unittest discover`: **37 Tests, OK**

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)