### PR TITLE
fix: restore REST/COA tools with trusted base URL fallback

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -43,6 +43,15 @@ timeout = 60.0
 # Default: 50
 max_results = 50
 
+# Trusted SOAR base URL fallback for internal REST/COA tool calls.
+# Normally the handler uses Splunk SOAR's authoritative on-box
+# phantom.rest.get_phantom_base_url() helper. If that helper is unavailable in
+# your SOAR app handler context, set this explicitly in local/mcp.conf or the
+# app asset configuration. This value is intentionally not derived from Host or
+# X-Forwarded-* request headers, because the SOAR auth token is sent to it.
+# Example:
+# base_url = https://soar.example.com
+
 # SSL verification for outbound calls to the SOAR REST API.
 #   true   : Verify using system CA bundle (default, recommended for production)
 #   false  : Disable verification (use only in dev/test with self-signed certs)

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -16,6 +16,7 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Set, Union
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,23 @@ def _manifest_app_version() -> str:
 
 # ── Valid values ───────────────────────────────────────────────────────────────
 _VALID_SEVERITIES = {"high", "medium", "low", "informational", ""}
+
+
+def normalise_base_url(raw: object) -> str:
+    """Return a trusted SOAR base URL without a trailing slash, or empty string."""
+    if not isinstance(raw, str):
+        return ""
+    val = raw.strip().rstrip("/")
+    if not val:
+        return ""
+    parsed = urlparse(val)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        logger.warning("[MCP Config] Ignoring invalid base_url '%s'.", val)
+        return ""
+    if parsed.username or parsed.password:
+        logger.warning("[MCP Config] Ignoring base_url with embedded credentials.")
+        return ""
+    return val
 
 # ── All known tool names ───────────────────────────────────────────────────────
 ALL_TOOLS: list[str] = [
@@ -133,6 +151,7 @@ class McpServerConfig:
     # [server] section
     timeout: float = 60.0
     max_results: int = 50
+    base_url: str = ""
     ssl_verify: Union[bool, str] = True
     log_tool_calls: bool = True
     protocol_version: str = "2024-11-05"
@@ -194,6 +213,7 @@ class McpServerConfig:
             "protocol_version": self.protocol_version,
             "server_name": self.server_name,
             "server_version": self.server_version,
+            "base_url_configured": bool(self.base_url),
             "ssl_verify": self.ssl_verify if isinstance(self.ssl_verify, bool) else "custom_path",
             "allowed_labels": self.allowed_labels,
             "min_severity": self.min_severity,
@@ -252,6 +272,10 @@ class McpConfigLoader:
         # ── [server] ──────────────────────────────────────────────────────────
         config.timeout = self._get_float(parser, "server", "timeout", 60.0, min_val=1.0, max_val=300.0)
         config.max_results = self._get_int(parser, "server", "max_results", 50, min_val=1, max_val=500)
+        config.base_url = normalise_base_url(
+            parser.get("server", "base_url", fallback="").strip()
+            or parser.get("server", "soar_base_url", fallback="").strip()
+        )
         config.ssl_verify = self._parse_ssl_verify(parser.get("server", "ssl_verify", fallback="true"))
         config.log_tool_calls = self._get_bool(parser, "server", "log_tool_calls", True)
         config.protocol_version = parser.get("server", "protocol_version", fallback="2024-11-05").strip()
@@ -363,6 +387,10 @@ class McpConfigLoader:
                 config.ssl_verify = ssl_override
             else:
                 config.ssl_verify = self._parse_ssl_verify(str(ssl_override))
+
+        base_url_override = normalise_base_url(overrides.get("base_url"))
+        if base_url_override:
+            config.base_url = base_url_override
 
         # Persist MCP endpoint URL so tools can display it
         mcp_ep = overrides.get("mcp_endpoint")

--- a/soar_mcp_handler.py
+++ b/soar_mcp_handler.py
@@ -29,7 +29,7 @@ _app_dir = os.path.dirname(os.path.abspath(__file__))
 if _app_dir not in sys.path:
     sys.path.insert(0, _app_dir)
 
-from soar_mcp_config import McpServerConfig, get_config
+from soar_mcp_config import McpServerConfig, get_config, normalise_base_url
 from soar_mcp_tools import TOOL_SCHEMAS, SoarApiClient, call_tool
 from soar_mcp_utils import redact_nested
 
@@ -131,8 +131,10 @@ class SoarMcpRestHandler(dict):
         # we don't track sessions server-side but accept and ignore it.
         session_id = meta.get("HTTP_MCP_SESSION_ID", "")
 
-        # Extract base URL from request for API callbacks
-        soar_base = self._extract_base_url(request)
+        # Extract base URL for API callbacks.
+        # Prefer SOAR's authoritative on-box helper; fall back only to trusted
+        # admin configuration. Never derive this from request headers (#58).
+        soar_base = self._extract_base_url(request, config)
 
         # Persist asset name for widget
         asset_name = path_args[0] if path_args else ""
@@ -231,6 +233,15 @@ class SoarMcpRestHandler(dict):
                     rpc_method,
                 )
                 return self._error(rpc_id, -32000, "Rate limit exceeded. Try again shortly.")
+
+        if rpc_method == "tools/call" and not soar_base:
+            return self._error(
+                rpc_id,
+                -32000,
+                "Unable to resolve SOAR base URL for MCP tool calls. "
+                "Configure the SOAR MCP Server asset base_url or [server] base_url "
+                "in mcp.conf, then run Test Connectivity.",
+            )
 
         # Build SOAR API client for tool calls
         client = SoarApiClient(soar_base, soar_call_token, config)
@@ -379,25 +390,28 @@ class SoarMcpRestHandler(dict):
                 "error": {"code": code, "message": message}}
 
     @staticmethod
-    def _extract_base_url(request) -> str:
+    def _extract_base_url(request, config: McpServerConfig | None = None) -> str:
         # Security (issue #58): the returned base_url is used to build the
         # SoarApiClient that sends the SOAR call token. It must come from the
         # authoritative SOAR system setting, NEVER from attacker-controllable
         # request headers (Host / X-Forwarded-*), which could redirect
         # token-bearing API calls to an attacker host (SSRF/credential exfil).
-        # phantom.rest.get_phantom_base_url() is authoritative on-box; if it is
-        # unavailable we fail closed (return "") rather than trust headers.
-        if request is None:
-            return ""
+        # phantom.rest.get_phantom_base_url() is authoritative on-box. Some SOAR
+        # 8.5 installations do not expose phantom.rest in app handler context,
+        # so we allow a trusted admin-configured fallback from the app asset or
+        # mcp.conf. If neither exists, fail closed with a clear MCP error.
         try:
             import phantom.rest as _pr
             url = _pr.get_phantom_base_url()
-            if url:
-                return url.rstrip("/")
+            base_url = normalise_base_url(url)
+            if base_url:
+                return base_url
         except Exception:
             pass
+        if config is not None and config.base_url:
+            return config.base_url
         logger.warning("[SOAR MCP] Could not resolve authoritative SOAR base URL; "
-                       "refusing to derive it from request headers.")
+                       "no trusted configured fallback is available.")
         return ""
 
     @staticmethod

--- a/test_soar_mcp_config_asset_overrides.py
+++ b/test_soar_mcp_config_asset_overrides.py
@@ -10,6 +10,47 @@ from soar_mcp_config import McpConfigLoader
 
 
 class SoarMcpConfigAssetOverridesTest(unittest.TestCase):
+    def test_server_base_url_is_normalised(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "default").mkdir()
+            (root / "local").mkdir()
+            (root / "default" / "mcp.conf").write_text(
+                "[server]\nbase_url = https://soar.example.com/\n", encoding="utf-8"
+            )
+
+            cfg = McpConfigLoader(root).load()
+
+        self.assertEqual(cfg.base_url, "https://soar.example.com")
+        self.assertTrue(cfg.to_summary_dict()["base_url_configured"])
+
+    def test_server_soar_base_url_alias_is_supported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "default").mkdir()
+            (root / "local").mkdir()
+            (root / "default" / "mcp.conf").write_text(
+                "[server]\nsoar_base_url = https://alias.example.com/\n", encoding="utf-8"
+            )
+
+            cfg = McpConfigLoader(root).load()
+
+        self.assertEqual(cfg.base_url, "https://alias.example.com")
+
+    def test_invalid_server_base_url_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "default").mkdir()
+            (root / "local").mkdir()
+            (root / "default" / "mcp.conf").write_text(
+                "[server]\nbase_url = soar.example.com\n", encoding="utf-8"
+            )
+
+            cfg = McpConfigLoader(root).load()
+
+        self.assertEqual(cfg.base_url, "")
+        self.assertFalse(cfg.to_summary_dict()["base_url_configured"])
+
     def test_ssl_verify_asset_override_is_applied(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -25,6 +66,22 @@ class SoarMcpConfigAssetOverridesTest(unittest.TestCase):
             cfg = McpConfigLoader(root).load()
 
         self.assertFalse(cfg.ssl_verify)
+
+    def test_asset_base_url_override_takes_precedence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "default").mkdir()
+            (root / "local").mkdir()
+            (root / "default" / "mcp.conf").write_text(
+                "[server]\nbase_url = https://conf.example.com\n", encoding="utf-8"
+            )
+            (root / "local" / "asset_overrides.json").write_text(
+                json.dumps({"base_url": "https://asset.example.com/"}), encoding="utf-8"
+            )
+
+            cfg = McpConfigLoader(root).load()
+
+        self.assertEqual(cfg.base_url, "https://asset.example.com")
 
 
 if __name__ == "__main__":

--- a/test_soar_mcp_handler_errors.py
+++ b/test_soar_mcp_handler_errors.py
@@ -1,6 +1,9 @@
 """Regression coverage for MCP handler error and dry-run semantics."""
 from __future__ import annotations
 
+import json
+import sys
+import types
 import unittest
 from unittest.mock import patch
 
@@ -10,6 +13,14 @@ from soar_mcp_handler import SoarMcpRestHandler
 
 class _FakeClient:
     pass
+
+
+class _FakeRequest:
+    method = "POST"
+    META = {"HTTP_PH_AUTH_TOKEN": "soar-token"}
+
+    def __init__(self, payload: dict) -> None:
+        self.body = json.dumps(payload).encode("utf-8")
 
 
 class SoarMcpHandlerErrorsTest(unittest.TestCase):
@@ -65,6 +76,53 @@ class SoarMcpHandlerErrorsTest(unittest.TestCase):
             None,
         )
         self.assertTrue(denied["isError"])
+
+    def test_extract_base_url_prefers_phantom_rest(self):
+        phantom_mod = types.ModuleType("phantom")
+        rest_mod = types.ModuleType("phantom.rest")
+        rest_mod.get_phantom_base_url = lambda: "https://system.example.com/"
+        phantom_mod.rest = rest_mod
+
+        cfg = McpServerConfig(base_url="https://configured.example.com")
+        with patch.dict(sys.modules, {"phantom": phantom_mod, "phantom.rest": rest_mod}):
+            self.assertEqual(
+                self.handler._extract_base_url(None, cfg),
+                "https://system.example.com",
+            )
+
+    def test_extract_base_url_uses_configured_fallback(self):
+        cfg = McpServerConfig(base_url="https://configured.example.com")
+        with patch.dict(sys.modules, {"phantom": None, "phantom.rest": None}):
+            self.assertEqual(
+                self.handler._extract_base_url(None, cfg),
+                "https://configured.example.com",
+            )
+
+    def test_extract_base_url_fails_closed_without_trusted_source(self):
+        with patch.dict(sys.modules, {"phantom": None, "phantom.rest": None}):
+            self.assertEqual(self.handler._extract_base_url(None, McpServerConfig()), "")
+
+    def test_tools_call_without_base_url_returns_clear_mcp_error(self):
+        cfg = McpServerConfig()
+        request = _FakeRequest(
+            {
+                "jsonrpc": "2.0",
+                "id": 93,
+                "method": "tools/call",
+                "params": {"name": "get_soar_info", "arguments": {}},
+            }
+        )
+
+        with (
+            patch("soar_mcp_handler.get_config", return_value=cfg),
+            patch.dict(sys.modules, {"phantom": None, "phantom.rest": None}),
+            patch("soar_mcp_handler.SoarApiClient") as api_client,
+        ):
+            result = self.handler._process(request, ["asset"])
+
+        api_client.assert_not_called()
+        self.assertEqual(result["id"], 93)
+        self.assertIn("Unable to resolve SOAR base URL", result["error"]["message"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_config.py`, `soar_mcp_handler.py`, `default/mcp.conf`, Handler/Config-Tests
- **Scope:** Base-URL-Auflösung für interne SOAR REST/COA Tool-Calls, Config-Parsing, Asset-Override-Fallback, klare MCP-Fehlermeldung bei fehlender trusted Base-URL
- **Was ändert sich:** `phantom.rest.get_phantom_base_url()` bleibt bevorzugt; wenn es im Handler-Kontext nicht verfügbar ist, nutzt der Handler eine explizit admin-konfigurierte `base_url` aus Asset-Overrides oder `[server] base_url` / `soar_base_url`; ohne trusted Quelle gibt es einen klaren JSON-RPC Fehler statt nachgelagertem `MissingSchema`.
- **Was bleibt unangetastet:** kein Fallback auf `Host`, `X-Forwarded-*` oder andere request-kontrollierte Header; Auth-/Token-Dispatch, Tool-Schema und REST-Client-Verhalten bleiben unverändert.

## Behobene Issues
| # | Fix |
|---|-----|
| #93 | REST/COA-backed MCP tools funktionieren wieder auf SOAR-Installationen, in denen `phantom.rest` im App-Handler-Kontext nicht importierbar ist. Der Fix behält die Security-Härtung aus #58 bei und erlaubt nur einen trusted/admin-konfigurierten Fallback. |

## Verifikation
- `python3 -m unittest discover -v`: **45 Tests, OK**
- `python3 -m compileall -q .`: OK
- Package-Linter: `OK — /tmp/soar_mcp_server_fix93_issue93_20260710T203142Z.tar passed all package hygiene checks.`
- Installiert auf SOAR 8.5.0.248 via `App.install_app_from_file`: App ID `7`, app_version `1.8.0`, same handler directory, `disabled=false`
- Trusted fallback gesetzt über `local/mcp.conf`: `[server] base_url = https://soar.hinterhof.dyndns.org`
- MCP smoke test über echten Handler:
  - `tools/list`: HTTP 200, 27 tools
  - `get_soar_info`: HTTP 200, reports SOAR `8.5.0.248`
  - `resolve_playbook_current_id`, `get_playbook_coa_summary`, `validate_playbook_bundle`: HTTP 200 / `ok=true` for playbooks `180`, `188`, `190`
- Playbook graph checks over MCP after the fix:
  - `180` monolithic playbook: 44 nodes / 51 edges, validation ok
  - `188` worker playbook: 9 nodes / 9 edges, validation ok
  - `190` analyze playbook: 28 nodes / 35 edges, validation ok

## Hinweis
Der PR bringt bewusst **nicht** den alten request-header-derived Base-URL-Fallback zurück. Wenn weder `phantom.rest` noch eine explizite Admin-Konfiguration verfügbar ist, bleiben Tool-Calls fail-closed und geben eine verständliche MCP-Fehlermeldung zurück.

Closes #93
