### PR TITLE
feat: structured response envelope helper (#74)

### DIFF
--- a/soar_mcp_envelope.py
+++ b/soar_mcp_envelope.py
@@ -1,0 +1,110 @@
+"""
+SOAR MCP Server — Structured Response Envelope (issue #74)
+
+A common response shape for tools that opt into structured output, plus a
+renderer that produces either human-readable text (the default, for interactive
+use) or JSON (for agents/automation).
+
+Envelope shape:
+    {
+        "ok":       bool,             # overall success
+        "summary":  str,              # one-line human summary
+        "data":     dict | list,      # tool-specific payload
+        "findings": list[dict],       # severity-tagged findings (optional)
+        "errors":   list[dict|str],   # error records (optional)
+    }
+
+The MCP handler already derives `isError` from `ok is False` or a non-empty
+`errors` list (soar_mcp_handler._is_tool_error), so envelope tools integrate
+with MCP error semantics without extra wiring.
+
+Migration is incremental: new tools use this first; legacy text tools keep their
+current behaviour until migrated. `output_format` ("text" | "json") lets a caller
+choose per-call.
+
+Copyright 2026 Andreas Buis
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+_VALID_FORMATS = ("text", "json")
+
+
+def make_envelope(
+    ok: bool,
+    summary: str,
+    *,
+    data: Any = None,
+    findings: Optional[list] = None,
+    errors: Optional[list] = None,
+) -> dict:
+    """Build a canonical response envelope."""
+    return {
+        "ok": bool(ok),
+        "summary": str(summary),
+        "data": data if data is not None else {},
+        "findings": list(findings) if findings else [],
+        "errors": list(errors) if errors else [],
+    }
+
+
+def normalize_output_format(value: Any, default: str = "text") -> str:
+    """Coerce a caller-supplied output_format to a valid value."""
+    v = str(value or default).strip().lower()
+    return v if v in _VALID_FORMATS else default
+
+
+def render_envelope(envelope: dict, fmt: str = "text") -> str:
+    """Render an envelope as JSON or human-readable text."""
+    fmt = normalize_output_format(fmt)
+    if fmt == "json":
+        return json.dumps(envelope, indent=2, default=str)
+
+    ok = envelope.get("ok")
+    lines = [f"{'✅' if ok else '❌'} {envelope.get('summary', '')}".rstrip()]
+
+    findings = envelope.get("findings") or []
+    if findings:
+        lines.append("")
+        lines.append("Findings:")
+        for f in findings:
+            if isinstance(f, dict):
+                sev = str(f.get("severity", "info")).upper()
+                msg = f.get("message") or f.get("summary") or f.get("code") or str(f)
+                lines.append(f"  [{sev}] {msg}")
+            else:
+                lines.append(f"  - {f}")
+
+    errors = envelope.get("errors") or []
+    if errors:
+        lines.append("")
+        lines.append("Errors:")
+        for e in errors:
+            if isinstance(e, dict):
+                lines.append(f"  - {e.get('safe_message') or e.get('message') or e}")
+            else:
+                lines.append(f"  - {e}")
+
+    data = envelope.get("data")
+    if data:
+        lines.append("")
+        lines.append("Data:")
+        lines.append(json.dumps(data, indent=2, default=str))
+
+    return "\n".join(lines)
+
+
+def envelope_response(
+    ok: bool,
+    summary: str,
+    *,
+    data: Any = None,
+    findings: Optional[list] = None,
+    errors: Optional[list] = None,
+    fmt: str = "text",
+) -> str:
+    """Convenience: build + render in one call. Returns the string a tool returns."""
+    env = make_envelope(ok, summary, data=data, findings=findings, errors=errors)
+    return render_envelope(env, fmt)

--- a/test_soar_mcp_envelope.py
+++ b/test_soar_mcp_envelope.py
@@ -1,0 +1,63 @@
+"""Tests for the structured response envelope (issue #74)."""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_envelope import (
+    envelope_response,
+    make_envelope,
+    normalize_output_format,
+    render_envelope,
+)
+
+
+class EnvelopeTest(unittest.TestCase):
+    def test_make_envelope_defaults(self):
+        e = make_envelope(True, "done")
+        self.assertEqual(e, {"ok": True, "summary": "done", "data": {}, "findings": [], "errors": []})
+
+    def test_normalize_output_format(self):
+        self.assertEqual(normalize_output_format("JSON"), "json")
+        self.assertEqual(normalize_output_format("bogus"), "text")
+        self.assertEqual(normalize_output_format(None), "text")
+        self.assertEqual(normalize_output_format("json", default="json"), "json")
+
+    def test_render_json_roundtrips(self):
+        e = make_envelope(False, "nope", data={"x": 1}, errors=["boom"])
+        out = render_envelope(e, "json")
+        parsed = json.loads(out)
+        self.assertEqual(parsed["ok"], False)
+        self.assertEqual(parsed["data"], {"x": 1})
+        self.assertEqual(parsed["errors"], ["boom"])
+
+    def test_render_text_has_markers_and_sections(self):
+        e = make_envelope(
+            True, "all good",
+            findings=[{"severity": "warn", "message": "watch out"}],
+            data={"k": "v"},
+        )
+        out = render_envelope(e, "text")
+        self.assertIn("✅ all good", out)
+        self.assertIn("[WARN] watch out", out)
+        self.assertIn("Data:", out)
+
+    def test_render_text_failure_marker(self):
+        out = render_envelope(make_envelope(False, "failed"), "text")
+        self.assertTrue(out.startswith("❌ failed"))
+
+    def test_envelope_response_convenience(self):
+        out = envelope_response(True, "ok", data={"a": 1}, fmt="json")
+        self.assertEqual(json.loads(out)["summary"], "ok")
+
+    def test_errors_dict_uses_safe_message(self):
+        out = render_envelope(
+            make_envelope(False, "x", errors=[{"safe_message": "auth failed", "message": "raw"}]),
+            "text",
+        )
+        self.assertIn("auth failed", out)
+        self.assertNotIn("raw", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_envelope.py` (neu), `test_soar_mcp_envelope.py` (neu)
- **Scope:** Envelope-Helper + Renderer — **kein** bestehendes Tool geändert
- **Was bleibt unangetastet:** alle vorhandenen Tools (Text-Default unverändert)

## Behobenes Issue — #74 (Phase 1, Foundation)
Kanonischer Envelope `{ok, summary, data, findings, errors}` + Text/JSON-Renderer + `output_format`-Normalisierung. Enabler für #67/#69/#70; erster Consumer wird #67.

## Verifikation
- `py_compile`: OK · `unittest discover`: **44 Tests, OK** (37 + 7 neu)
- Integriert mit `_is_tool_error` (isError aus ok=false/errors)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)