### PR TITLE
feat: security posture report in Test Connectivity (#51)

### DIFF
--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -201,6 +201,49 @@ class McpServerConfig:
         }
 
 
+def build_posture_report(config: "McpServerConfig") -> dict:
+    """Return the effective security posture of this asset (issue #51).
+
+    Shared by Test Connectivity (#51) and the diagnostics tool (#67) so both
+    surfaces report identical, non-secret state. Contains no tokens or secrets.
+    """
+    try:
+        from soar_mcp_tokens import _have_fernet
+        fernet_available = bool(_have_fernet())
+    except Exception:
+        fernet_available = False
+
+    enabled_write = sorted(config.enabled_tools - READ_ONLY_TOOLS)
+    ssl = config.ssl_verify if isinstance(config.ssl_verify, bool) else "custom_path"
+
+    # Coarse risk flags for a quick red/yellow/green read — advisory only.
+    risk_flags: list[str] = []
+    if enabled_write and ssl is False:
+        risk_flags.append("write_tools_enabled_with_ssl_verify_off")
+    if config.enable_test_harness:
+        risk_flags.append("test_harness_enabled")
+    if enabled_write and not config.require_confirmation:
+        risk_flags.append("write_tools_without_confirmation")
+    if config.scoped_tokens_enabled and not fernet_available:
+        risk_flags.append("scoped_tokens_without_fernet_encryption")
+    if config.scoped_tokens_enabled and not config.scoped_tokens_required and enabled_write:
+        risk_flags.append("legacy_full_tokens_still_accepted")
+
+    return {
+        "write_tools_enabled": config.write_tools_enabled,
+        "enabled_write_tools": enabled_write,
+        "ssl_verify": ssl,
+        "enable_test_harness": config.enable_test_harness,
+        "require_confirmation": config.require_confirmation,
+        "scoped_tokens_enabled": config.scoped_tokens_enabled,
+        "scoped_tokens_required": config.scoped_tokens_required,
+        "fernet_available": fernet_available,
+        "legacy_path_rate_limited": config.token_rate_limit_per_minute > 0,
+        "advisory_disclaimer": config.advisory_disclaimer,
+        "risk_flags": risk_flags,
+    }
+
+
 class McpConfigLoader:
     """
     Loads and parses mcp.conf following Splunk/SOAR config precedence.

--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -21,7 +21,13 @@ _app_dir = os.path.dirname(os.path.abspath(__file__))
 if _app_dir not in sys.path:
     sys.path.insert(0, _app_dir)
 
-from soar_mcp_config import ALL_TOOLS, READ_ONLY_TOOLS, McpConfigLoader, get_config
+from soar_mcp_config import (
+    ALL_TOOLS,
+    READ_ONLY_TOOLS,
+    McpConfigLoader,
+    build_posture_report,
+    get_config,
+)
 from soar_mcp_handler import build_mcp_endpoint
 
 try:
@@ -261,16 +267,19 @@ class SoarMcpConnector(BaseConnector):
                 self.debug_print(f"[MCP] Token purge skipped: {exc}")
                 self.save_progress("Token purge skipped.")
 
+        posture = build_posture_report(config)
         action_result.add_data({
             "mcp_endpoint": mcp_endpoint,
             "enabled_tools": sorted(config.enabled_tools),
             "config_summary": config.to_summary_dict(),
+            "security_posture": posture,
         })
         action_result.set_summary({
             "mcp_endpoint": mcp_endpoint,
             "enabled_tools": len(config.enabled_tools),
             "write_tools_enabled": config.write_tools_enabled,
             "tokens_purged": purged,
+            "posture_risk_flags": len(posture["risk_flags"]),
         })
         return action_result.set_status(
             phantom.APP_SUCCESS,


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_config.py`, `soar_mcp_connector.py`
- **Scope:** `build_posture_report` (neu), `_handle_test_connectivity`
- **Was bleibt unangetastet:** Tool-Logik, Auth, restliche Actions

## Behobenes Issue — #51 (Phase 2)
Gemeinsamer `build_posture_report(config)` — secret-freie Sicht auf die effektive Posture (write tools, ssl_verify, test harness, require_confirmation, scoped tokens, Fernet, Legacy-Rate-Limit) + grobe `risk_flags`. In Test Connectivity eingehängt; **geteilter Helper** für #67 (identische Daten über MCP).

## Verifikation
- `py_compile`: OK
- Smoke-Test: write+ssl_off+harness → 3 erwartete risk_flags; clean config → keine
- `unittest discover`: **55 Tests, OK**

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)