### PR TITLE
feat: read-only diagnose_soar_mcp_environment tool (#67)

### DIFF
--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -83,6 +83,8 @@ ALL_TOOLS: list[str] = [
     "save_playbook_layout_only",
     # Client config helper (v1.8.0+)
     "generate_mcp_client_config",
+    # Diagnostics (v1.9.0+)
+    "diagnose_soar_mcp_environment",
 ]
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(
@@ -117,6 +119,8 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "check_visual_editor_compat",
         # Client config helper (v1.8.0+)
         "generate_mcp_client_config",
+        # Diagnostics (v1.9.0+)
+        "diagnose_soar_mcp_environment",
     ]
 )
 

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -341,6 +341,13 @@
             "default": true,
             "required": false,
             "order": 81
+        },
+        "tool_diagnose_soar_mcp_environment": {
+            "description": "READ \u2014 diagnose_soar_mcp_environment: Read-only diagnostics (app version, endpoint shape, handler reachability, /rest/version probe, security posture). Never returns token values.",
+            "data_type": "boolean",
+            "default": true,
+            "required": false,
+            "order": 82
         }
     },
     "actions": [

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -3949,6 +3949,86 @@ TOOL_SCHEMAS["generate_mcp_client_config"] = {
     "inputSchema": {"type": "object", "properties": {}},
 }
 
+def tool_diagnose_soar_mcp_environment(
+    client: SoarApiClient, config: McpServerConfig, args: dict
+) -> str:
+    """Read-only diagnostics: is the installed MCP endpoint usable, and why not?
+    (issue #67). First consumer of the structured envelope (#74), the posture
+    report (#51), and the error classifier (#70). Never returns token values."""
+    from soar_mcp_config import build_posture_report
+    from soar_mcp_envelope import envelope_response, normalize_output_format
+
+    fmt = normalize_output_format(args.get("output_format"))
+    findings: list[dict] = []
+    errors: list[dict] = []
+
+    endpoint = config.mcp_endpoint or "(unknown — run Test Connectivity)"
+    auth_present = bool(getattr(client, "_auth_token", ""))
+    if not auth_present:
+        findings.append({"severity": "error", "code": "no_auth_token",
+                         "message": "No ph-auth-token was presented on this request."})
+
+    # Safe reachability probe: GET /rest/version.
+    soar_version = None
+    handler_reachable = False
+    ver, ver_err = client.get("version")
+    if ver_err:
+        info = None
+        errors.append({"category": "probe", "safe_message": ver_err,
+                       "endpoint_category": "rest/version"})
+        findings.append({"severity": "warn", "code": "version_probe_failed",
+                         "message": f"/rest/version probe failed: {ver_err}"})
+    else:
+        handler_reachable = True
+        if isinstance(ver, dict):
+            soar_version = ver.get("version") or ver.get("rest_version")
+
+    posture = build_posture_report(config)
+    for flag in posture.get("risk_flags", []):
+        findings.append({"severity": "warn", "code": flag,
+                         "message": f"Security posture: {flag}"})
+
+    data = {
+        "app_version": config.server_version,
+        "mcp_endpoint": endpoint,
+        "auth_token_present": auth_present,   # presence only, never the value
+        "handler_reachable": handler_reachable,
+        "soar_version": soar_version,
+        "enabled_tool_count": len(config.enabled_tools),
+        "security_posture": posture,
+    }
+    ok = auth_present and handler_reachable and not any(
+        f.get("severity") == "error" for f in findings
+    )
+    summary = (
+        "SOAR MCP environment looks usable."
+        if ok else
+        "SOAR MCP environment has issues — see findings."
+    )
+    return envelope_response(ok, summary, data=data, findings=findings,
+                             errors=errors, fmt=fmt)
+
+
+TOOL_SCHEMAS["diagnose_soar_mcp_environment"] = {
+    "description": (
+        "Read-only diagnostics for this SOAR MCP endpoint: reports app version, "
+        "endpoint shape, handler reachability, a safe /rest/version probe, and the "
+        "security posture with actionable findings. Never returns token values. "
+        "Use output_format=json for structured output."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "output_format": {
+                "type": "string",
+                "description": "Output format: 'text' (default) or 'json'.",
+                "enum": ["text", "json"],
+            },
+        },
+    },
+}
+
+
 TOOL_SCHEMAS["delete_container"] = {
     "description": (
         "WRITE — Delete a test container by ID to clean up after playbook self-tests. "
@@ -4011,6 +4091,8 @@ _TOOL_HANDLERS = {
     "generate_mcp_client_config": tool_generate_mcp_client_config,
     # Test-harness cleanup (v1.8.0+)
     "delete_container": tool_delete_container,
+    # Diagnostics (v1.9.0+)
+    "diagnose_soar_mcp_environment": tool_diagnose_soar_mcp_environment,
 }
 
 

--- a/test_soar_mcp_diagnostics.py
+++ b/test_soar_mcp_diagnostics.py
@@ -1,0 +1,60 @@
+"""Tests for the diagnostics tool (issue #67)."""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_config import READ_ONLY_TOOLS, McpServerConfig
+from soar_mcp_tools import call_tool
+
+
+class _FakeClient:
+    def __init__(self, auth="tok", version="6.3.0", fail=False):
+        self._auth_token = auth
+        self._version = version
+        self._fail = fail
+
+    def get(self, path, params=None):
+        if path == "version" and not self._fail:
+            return {"version": self._version}, None
+        return None, "Connection error: could not reach SOAR REST API."
+
+
+def _cfg():
+    c = McpServerConfig()
+    c.mcp_endpoint = "https://soar.x/rest/handler/soarmcpserver_a/mcp"
+    c.enabled_tools = set(READ_ONLY_TOOLS)
+    return c
+
+
+class DiagnosticsTest(unittest.TestCase):
+    def test_healthy_environment_ok(self):
+        out = call_tool("diagnose_soar_mcp_environment", {"output_format": "json"},
+                        _FakeClient(), _cfg())
+        d = json.loads(out)
+        self.assertTrue(d["ok"], d)
+        self.assertTrue(d["data"]["handler_reachable"])
+        self.assertEqual(d["data"]["soar_version"], "6.3.0")
+
+    def test_unreachable_marks_not_ok(self):
+        out = call_tool("diagnose_soar_mcp_environment", {"output_format": "json"},
+                        _FakeClient(fail=True), _cfg())
+        d = json.loads(out)
+        self.assertFalse(d["ok"])
+        self.assertFalse(d["data"]["handler_reachable"])
+
+    def test_never_leaks_token(self):
+        out = call_tool("diagnose_soar_mcp_environment", {},
+                        _FakeClient(auth="SUPER-SECRET"), _cfg())
+        self.assertNotIn("SUPER-SECRET", out)
+
+    def test_missing_token_is_error_finding(self):
+        out = call_tool("diagnose_soar_mcp_environment", {"output_format": "json"},
+                        _FakeClient(auth=""), _cfg())
+        d = json.loads(out)
+        self.assertFalse(d["ok"])
+        self.assertTrue(any(f.get("code") == "no_auth_token" for f in d["findings"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_tools.py`, `soar_mcp_config.py`, `soar_mcp_server.json`, `test_soar_mcp_diagnostics.py`
- **Scope:** neues read-only Tool `diagnose_soar_mcp_environment` + Registrierung + Checkbox
- **Was bleibt unangetastet:** bestehende Tools

## Behobenes Issue — #67 (Phase 2)
Read-only In-Band-Diagnostics — **erster Consumer** von Envelope (#74), Posture (#51) und Error-Klassifikator (#70). App-Version, Endpoint-Shape, Handler-Erreichbarkeit (`/rest/version`-Probe), SOAR-Version, Security-Posture + Findings. `output_format=text|json`.

## Sicherheit
- Nur **Präsenz** des `ph-auth-token` (nie der Wert) — per Test verifiziert
- read-only, keine Writes

## Verifikation
- `py_compile` + Manifest valide; kein `delete_container`-Duplikat in ALL_TOOLS
- Smoke-Test: kein Token-Leak; JSON+Text-Render; Findings aus Posture; reachable/unreachable-Pfade
- `unittest discover`: **59 Tests, OK** (55 + 4 neu)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)