### PR TITLE
feat: capability detection layer + detect tool (#68 part 1)

### DIFF
--- a/soar_mcp_capabilities.py
+++ b/soar_mcp_capabilities.py
@@ -1,0 +1,111 @@
+"""
+SOAR MCP Server — Capability Detection Layer (issue #68, part 1)
+
+Runtime detection of how *this* SOAR instance actually behaves, instead of
+version-only assumptions. Verified against SOAR 8.5.0.248, where:
+  - /coa/playbooks/{id} returns an extractable node/edge graph (live),
+  - the export archive is available as a fallback,
+  - the REST playbook record carries a Python payload ("rest_python"),
+  - there is NO /rest/playbook/{id}/validate endpoint (passed_validation flag),
+  - pylint is available server-side.
+
+This module only *detects and reports* capabilities (read-only probes). Rewiring
+the internal COA consumers (_get_coa_nodes_edges / _select_playbook_python /
+_resolve_current_id) to consume the report is a deliberate, separately-tested
+follow-up so the freshly-restabilised COA paths are not destabilised.
+
+Copyright 2026 Andreas Buis
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+
+@dataclass
+class CapabilityReport:
+    """Observed capabilities of a SOAR instance's playbook/COA surface."""
+    coa_endpoint_available: bool = False
+    coa_graph_extractable: bool = False
+    export_fallback_available: bool = False
+    python_source: str = "none"          # rest_python | coa_python | export_archive | coa_usercode | none
+    validation_method: str = "unknown"   # passed_validation_flag | validate_endpoint | none
+    node_count: Optional[int] = None
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _coa_data_has_nodes(coa_data: Any) -> tuple[bool, Optional[int]]:
+    """Best-effort: does a COA payload expose an extractable node collection?
+    Mirrors the shapes _get_coa_nodes_edges handles (A–D), without importing it
+    (keeps this module dependency-light and safe to unit-test in isolation)."""
+    if not isinstance(coa_data, dict):
+        return False, None
+    coa_sub = coa_data.get("coa") or {}
+    data_sub = coa_sub.get("data") or coa_data.get("data") or {}
+    cd = coa_data.get("coa_data")
+    if isinstance(cd, dict):
+        data_sub = data_sub or cd
+    nodes = (
+        (data_sub.get("nodes") if isinstance(data_sub, dict) else None)
+        or (cd.get("nodes") if isinstance(cd, dict) else None)
+        or coa_data.get("nodes")
+    )
+    if isinstance(nodes, dict):
+        return (len(nodes) > 0), len(nodes)
+    if isinstance(nodes, list):
+        return (len(nodes) > 0), len(nodes)
+    # No explicit node collection, but a count field still signals a live graph.
+    nc = coa_data.get("node_count")
+    if isinstance(nc, int):
+        return (nc > 0), nc
+    return False, None
+
+
+def detect_capabilities(client, sample_playbook_id: int) -> CapabilityReport:
+    """Probe a known-good playbook id with safe, read-only calls and report what
+    this SOAR instance actually supports. Never raises — degrades to a report
+    with notes on any probe failure."""
+    report = CapabilityReport()
+
+    # 1. COA endpoint + graph extractability.
+    coa_data, coa_err = client._coa_get(f"playbooks/{sample_playbook_id}")
+    if coa_err:
+        report.notes.append(f"coa_probe_failed: {coa_err}")
+    else:
+        report.coa_endpoint_available = True
+        has_nodes, nc = _coa_data_has_nodes(coa_data)
+        report.coa_graph_extractable = has_nodes
+        report.node_count = nc
+        if not has_nodes:
+            report.notes.append("coa_endpoint_available_but_nodes_not_extractable")
+
+    # 2. Python source (prefer REST record; else export archive availability).
+    rest_data, rest_err = client.get(f"playbook/{sample_playbook_id}")
+    if isinstance(rest_data, dict) and any(
+        isinstance(rest_data.get(k), str) and rest_data.get(k).strip()
+        for k in ("python", "code", "script", "playbook_run_data")
+    ):
+        report.python_source = "rest_python"
+        report.validation_method = (
+            "passed_validation_flag" if "passed_validation" in rest_data else "unknown"
+        )
+    elif rest_err:
+        report.notes.append(f"rest_probe_failed: {rest_err}")
+
+    # 3. Export fallback availability (binary archive).
+    content, exp_err = client.get_binary(f"playbook/{sample_playbook_id}/export")
+    if content:
+        report.export_fallback_available = True
+        if report.python_source == "none":
+            report.python_source = "export_archive"
+    elif exp_err:
+        report.notes.append(f"export_probe_failed: {exp_err}")
+
+    if report.validation_method == "unknown" and report.coa_endpoint_available:
+        # SOAR 8.5 has no /validate endpoint; passed_validation is the signal.
+        report.validation_method = "passed_validation_flag"
+
+    return report

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -85,6 +85,8 @@ ALL_TOOLS: list[str] = [
     "generate_mcp_client_config",
     # Diagnostics (v1.9.0+)
     "diagnose_soar_mcp_environment",
+    # Capability detection (v1.10.0+)
+    "detect_soar_capabilities",
 ]
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(
@@ -121,6 +123,8 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "generate_mcp_client_config",
         # Diagnostics (v1.9.0+)
         "diagnose_soar_mcp_environment",
+        # Capability detection (v1.10.0+)
+        "detect_soar_capabilities",
     ]
 )
 

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -348,6 +348,13 @@
             "default": true,
             "required": false,
             "order": 82
+        },
+        "tool_detect_soar_capabilities": {
+            "description": "READ \u2014 detect_soar_capabilities: Detect how this SOAR instance's playbook/COA surface behaves (COA graph, export fallback, Python source, validation method) by probing one known-good playbook.",
+            "data_type": "boolean",
+            "default": true,
+            "required": false,
+            "order": 83
         }
     },
     "actions": [

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -4029,6 +4029,58 @@ TOOL_SCHEMAS["diagnose_soar_mcp_environment"] = {
 }
 
 
+def tool_detect_soar_capabilities(
+    client: SoarApiClient, config: McpServerConfig, args: dict
+) -> str:
+    """Read-only: detect how this SOAR instance's playbook/COA surface behaves
+    (issue #68). Probes a known-good playbook and reports the capability map."""
+    from soar_mcp_capabilities import detect_capabilities
+    from soar_mcp_envelope import envelope_response, normalize_output_format
+
+    fmt = normalize_output_format(args.get("output_format"))
+
+    pid, err = _require_positive_int(args.get("playbook_id"), "playbook_id") \
+        if args.get("playbook_id") is not None else (None, None)
+    if err:
+        return err
+    if pid is None:
+        # Auto-pick the first available playbook as the probe sample.
+        data, list_err = client.get("playbook", params={"page_size": 1})
+        items = data if isinstance(data, list) else (data or {}).get("data", [])
+        if not items:
+            return envelope_response(
+                False, "No playbook available to probe capabilities.",
+                errors=[{"safe_message": list_err or "no playbooks found"}], fmt=fmt)
+        pid = items[0].get("id")
+
+    report = detect_capabilities(client, int(pid))
+    findings = [{"severity": "info", "code": n} for n in report.notes]
+    ok = report.coa_endpoint_available or report.export_fallback_available
+    summary = (
+        f"Capabilities probed via playbook {pid}: "
+        f"coa={'live' if report.coa_graph_extractable else 'summary-only' if report.coa_endpoint_available else 'unavailable'}, "
+        f"python_source={report.python_source}, export_fallback={report.export_fallback_available}."
+    )
+    return envelope_response(ok, summary, data=report.to_dict(),
+                             findings=findings, fmt=fmt)
+
+
+TOOL_SCHEMAS["detect_soar_capabilities"] = {
+    "description": (
+        "READ — Detect how this SOAR instance's playbook/COA surface actually "
+        "behaves (COA graph availability, export fallback, Python payload source, "
+        "validation method). Probes one known-good playbook. output_format=text|json."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "playbook_id": {"type": "integer", "description": "Playbook to probe (default: first available)."},
+            "output_format": {"type": "string", "enum": ["text", "json"], "description": "Output format (default text)."},
+        },
+    },
+}
+
+
 TOOL_SCHEMAS["delete_container"] = {
     "description": (
         "WRITE — Delete a test container by ID to clean up after playbook self-tests. "
@@ -4093,6 +4145,8 @@ _TOOL_HANDLERS = {
     "delete_container": tool_delete_container,
     # Diagnostics (v1.9.0+)
     "diagnose_soar_mcp_environment": tool_diagnose_soar_mcp_environment,
+    # Capability detection (v1.10.0+)
+    "detect_soar_capabilities": tool_detect_soar_capabilities,
 }
 
 

--- a/test_soar_mcp_capabilities.py
+++ b/test_soar_mcp_capabilities.py
@@ -1,0 +1,90 @@
+"""Tests for the capability detection layer (issue #68).
+
+Shapes are grounded in real observations from SOAR 8.5.0.248:
+  - /coa/playbooks/{id} returns node_count and an extractable graph,
+  - the REST record carries a python payload ("rest_python"),
+  - the export archive is available.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_capabilities import _coa_data_has_nodes, detect_capabilities
+from soar_mcp_config import READ_ONLY_TOOLS, McpServerConfig
+from soar_mcp_tools import call_tool
+
+
+class _Fake85Client:
+    """Mimics the verified 8.5.0.248 behavior after the base_url fix."""
+    def __init__(self, coa_nodes=6, rest_python=True, export=True):
+        self._coa_nodes = coa_nodes
+        self._rest_python = rest_python
+        self._export = export
+
+    def _coa_get(self, path, params=None):
+        return {"id": 1, "node_count": self._coa_nodes,
+                "coa_data": {"nodes": {str(i): {} for i in range(self._coa_nodes)}}}, None
+
+    def get(self, path, params=None):
+        if path.startswith("playbook/"):
+            rec = {"id": 1, "passed_validation": True}
+            if self._rest_python:
+                rec["python"] = "def on_start(c):\n    pass\n"
+            return rec, None
+        if path == "playbook":
+            return {"data": [{"id": 1}]}, None
+        return {}, None
+
+    def get_binary(self, path, params=None):
+        return (b"TARBYTES", None) if self._export else (None, "404")
+
+
+class ShapeExtractionTest(unittest.TestCase):
+    def test_dict_nodes(self):
+        ok, n = _coa_data_has_nodes({"coa_data": {"nodes": {"0": {}, "1": {}}}})
+        self.assertTrue(ok)
+        self.assertEqual(n, 2)
+
+    def test_count_only(self):
+        ok, n = _coa_data_has_nodes({"node_count": 6})
+        self.assertTrue(ok)
+        self.assertEqual(n, 6)
+
+    def test_empty(self):
+        ok, n = _coa_data_has_nodes({"foo": "bar"})
+        self.assertFalse(ok)
+
+
+class DetectCapabilitiesTest(unittest.TestCase):
+    def test_full_85_profile(self):
+        r = detect_capabilities(_Fake85Client(), 1)
+        self.assertTrue(r.coa_endpoint_available)
+        self.assertTrue(r.coa_graph_extractable)
+        self.assertEqual(r.node_count, 6)
+        self.assertEqual(r.python_source, "rest_python")
+        self.assertTrue(r.export_fallback_available)
+        self.assertEqual(r.validation_method, "passed_validation_flag")
+
+    def test_export_only_python_fallback(self):
+        r = detect_capabilities(_Fake85Client(rest_python=False), 1)
+        self.assertEqual(r.python_source, "export_archive")
+
+    def test_tool_registered_read_only(self):
+        from soar_mcp_tools import TOOL_SCHEMAS, _TOOL_HANDLERS
+        self.assertIn("detect_soar_capabilities", TOOL_SCHEMAS)
+        self.assertIn("detect_soar_capabilities", _TOOL_HANDLERS)
+        self.assertIn("detect_soar_capabilities", READ_ONLY_TOOLS)
+
+    def test_tool_json_envelope(self):
+        cfg = McpServerConfig()
+        cfg.enabled_tools = set(READ_ONLY_TOOLS)
+        out = call_tool("detect_soar_capabilities",
+                        {"playbook_id": 1, "output_format": "json"}, _Fake85Client(), cfg)
+        d = json.loads(out)
+        self.assertTrue(d["ok"])
+        self.assertEqual(d["data"]["python_source"], "rest_python")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_capabilities.py` (neu), `soar_mcp_tools.py`, `soar_mcp_config.py`, `soar_mcp_server.json`, `test_soar_mcp_capabilities.py` (neu)
- **Scope:** `CapabilityReport`/`detect_capabilities` + read-only `detect_soar_capabilities` Tool
- **Was bleibt unangetastet:** interne COA-Consumer (bewusst NICHT umverdrahtet — Follow-up)

## Issue #68 — Teil 1 (Detection-Schicht)
Laufzeit-Erkennung statt Versions-Annahmen: COA-Graph-Verfügbarkeit, Export-Fallback, Python-Quelle, Validation-Methode — via read-only Probes eines bekannten Playbooks. **Gegründet auf live verifizierten Shapes (SOAR 8.5.0.248):** live COA-Graph, `rest_python`, Export-Fallback, `passed_validation`.

## Scope-Hinweis
Bewusst **nur Detection + Reporting**. Das Umverdrahten der internen Consumer (`_get_coa_nodes_edges`/`_select_playbook_python`/`_resolve_current_id`) ist ein separater Follow-up, um die gerade restabilisierten COA-Pfade nicht zu gefährden. **#68 bleibt dafür offen.**

## Verifikation
- `py_compile` + Manifest valide
- `unittest discover`: **71 Tests, OK** (64 + 7 neu, gegen echte 8.5-Shapes)
- Live-Test des Tools nach Deployment

Teil 1 von #68. 🤖 Generated with [Claude Code](https://claude.com/claude-code)