### PR TITLE
feat: audit_visual_playbook pre-edit audit tool (#69)

### DIFF
--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -87,6 +87,8 @@ ALL_TOOLS: list[str] = [
     "diagnose_soar_mcp_environment",
     # Capability detection (v1.10.0+)
     "detect_soar_capabilities",
+    # Visual playbook pre-edit audit (v1.11.0+)
+    "audit_visual_playbook",
 ]
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(
@@ -125,6 +127,8 @@ READ_ONLY_TOOLS: frozenset[str] = frozenset(
         "diagnose_soar_mcp_environment",
         # Capability detection (v1.10.0+)
         "detect_soar_capabilities",
+        # Visual playbook pre-edit audit (v1.11.0+)
+        "audit_visual_playbook",
     ]
 )
 

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -355,6 +355,13 @@
             "default": true,
             "required": false,
             "order": 83
+        },
+        "tool_audit_visual_playbook": {
+            "description": "READ \u2014 audit_visual_playbook: One-call pre-edit audit of a Visual Editor playbook (stale/current, counts, warnings/errors, trigger/type, Python source, validation + drift, recommendations). Verdict pass/warn/fail/unknown.",
+            "data_type": "boolean",
+            "default": true,
+            "required": false,
+            "order": 84
         }
     },
     "actions": [

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -3734,6 +3734,99 @@ def tool_check_visual_editor_compat(
     return json.dumps(result, indent=2)
 
 
+def tool_audit_visual_playbook(
+    client: SoarApiClient, config: McpServerConfig, args: dict
+) -> str:
+    """Read-only pre-edit audit (issue #69): one call → is this playbook safe to
+    inspect/edit in the VPE? Composes COA summary + compat check + capability
+    detection into a severity-tagged audit with operator recommendations.
+    Consumes #68 so it never claims 'safe' when required data is unknown."""
+    from soar_mcp_capabilities import detect_capabilities
+    from soar_mcp_envelope import envelope_response, normalize_output_format
+
+    fmt = normalize_output_format(args.get("output_format"))
+    pid, err_msg = _require_positive_int(args.get("playbook_id"), "playbook_id")
+    if err_msg:
+        return err_msg
+
+    findings: list[dict] = []
+    errors: list[dict] = []
+    data: dict = {"input_id": pid}
+
+    # 1. COA summary (trigger, type, counts, passed_validation).
+    try:
+        summ = json.loads(tool_get_playbook_coa_summary(client, config, {"playbook_id": pid}))
+        sd = summ.get("data") or {}
+        data.update({
+            "current_id": sd.get("current_id"),
+            "name": sd.get("name"),
+            "trigger": sd.get("trigger"),
+            "playbook_type": sd.get("playbook_type"),
+            "passed_validation": sd.get("passed_validation"),
+            "node_count": sd.get("node_count"),
+            "edge_count": sd.get("edge_count"),
+            "warning_count": sd.get("warning_count"),
+            "error_count": sd.get("error_count"),
+        })
+        for e in summ.get("errors", []):
+            errors.append(e)
+    except Exception as exc:
+        errors.append({"safe_message": f"coa_summary failed: {type(exc).__name__}"})
+
+    # 2. Compat findings (reuse the working aggregator; do not modify it).
+    try:
+        compat = json.loads(tool_check_visual_editor_compat(client, config, {"playbook_id": pid}))
+        for f in compat.get("findings", []):
+            findings.append(f)
+        for e in compat.get("errors", []):
+            errors.append(e)
+    except Exception as exc:
+        errors.append({"safe_message": f"compat_check failed: {type(exc).__name__}"})
+
+    # 3. Capability context (#68): don't promise 'safe' when data is unknown.
+    caps = detect_capabilities(client, int(data.get("current_id") or pid))
+    data["capabilities"] = caps.to_dict()
+    inspectable = caps.coa_graph_extractable or caps.export_fallback_available
+    python_known = caps.python_source != "none"
+
+    # 4. Verdict — explicit unknown vs pass/warn/fail.
+    sev_rank = {"high": 3, "warn": 2, "medium": 2, "low": 1, "info": 0}
+    max_sev = max((sev_rank.get(f.get("severity", "low"), 0) for f in findings), default=0)
+    if not inspectable:
+        verdict = "unknown"
+    elif max_sev >= 3 or data.get("error_count"):
+        verdict = "fail"
+    elif max_sev >= 2 or not python_known:
+        verdict = "warn"
+    else:
+        verdict = "pass"
+    data["verdict"] = verdict
+
+    # 5. Operator recommendations.
+    recs: list[str] = []
+    if verdict == "unknown":
+        recs.append("COA graph and export archive are both unavailable — cannot audit; "
+                    "check connectivity/permissions before editing.")
+    if not python_known:
+        recs.append("Generated Python could not be inspected — drift status is unknown; "
+                    "review helper functions manually before saving in the VPE.")
+    if data.get("error_count"):
+        recs.append("Resolve stored node errors before editing.")
+    if any(f.get("code") == "stale_id" for f in findings):
+        recs.append(f"You passed a stale revision; edit the current draft "
+                    f"(id={data.get('current_id')}).")
+    if not recs:
+        recs.append("No blocking issues detected — safe to inspect/edit.")
+    data["recommendations"] = recs
+
+    ok = verdict in ("pass", "warn")
+    summary = (f"Visual playbook audit for '{data.get('name') or pid}' "
+               f"(id={data.get('current_id') or pid}): {verdict.upper()} — "
+               f"{data.get('node_count')} nodes, {len(findings)} finding(s).")
+    return envelope_response(ok, summary, data=data, findings=findings,
+                             errors=errors, fmt=fmt)
+
+
 # ── #29 save_playbook_layout_only (WRITE, guarded) ────────────────────────────
 
 def tool_save_playbook_layout_only(
@@ -4080,6 +4173,24 @@ TOOL_SCHEMAS["detect_soar_capabilities"] = {
     },
 }
 
+TOOL_SCHEMAS["audit_visual_playbook"] = {
+    "description": (
+        "READ — Pre-edit audit of a Visual Editor playbook: one call returns "
+        "stale/current status, node/edge counts, warnings/errors, trigger/type, "
+        "Python payload source, validation + drift summary, and operator "
+        "recommendations. Verdict is pass/warn/fail/unknown — never claims 'safe' "
+        "when required data is unavailable. output_format=text|json."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "playbook_id": {"type": "integer", "description": "Playbook to audit (current or stale — resolved automatically)."},
+            "output_format": {"type": "string", "enum": ["text", "json"], "description": "Output format (default text)."},
+        },
+        "required": ["playbook_id"],
+    },
+}
+
 
 TOOL_SCHEMAS["delete_container"] = {
     "description": (
@@ -4147,6 +4258,8 @@ _TOOL_HANDLERS = {
     "diagnose_soar_mcp_environment": tool_diagnose_soar_mcp_environment,
     # Capability detection (v1.10.0+)
     "detect_soar_capabilities": tool_detect_soar_capabilities,
+    # Visual playbook pre-edit audit (v1.11.0+)
+    "audit_visual_playbook": tool_audit_visual_playbook,
 }
 
 

--- a/test_soar_mcp_audit.py
+++ b/test_soar_mcp_audit.py
@@ -1,0 +1,92 @@
+"""Tests for the visual playbook pre-edit audit (issue #69)."""
+from __future__ import annotations
+
+import json
+import unittest
+
+from soar_mcp_config import READ_ONLY_TOOLS, McpServerConfig
+from soar_mcp_tools import call_tool
+
+
+class _HealthyClient:
+    """Mimics verified 8.5.0.248 shapes for a clean playbook."""
+    def _coa_get(self, path, params=None):
+        return {
+            "id": 1, "current_id": 1, "name": "AD_LDAP_Account_Locking",
+            "playbook_trigger": "artifact_created", "playbook_type": "data",
+            "passed_validation": True, "node_count": 6,
+            "coa_data": {"nodes": {str(i): {"data": {"functionName": f"n{i}"}} for i in range(6)},
+                         "edges": [{"source": "0", "target": "1"}]},
+        }, None
+
+    def get(self, path, params=None):
+        if path.startswith("playbook/"):
+            return {"id": 1, "passed_validation": True,
+                    "python": "def on_start(c):\n    pass\n"}, None
+        if path == "playbook":
+            return {"data": [{"id": 1}]}, None
+        return {}, None
+
+    def get_binary(self, path, params=None):
+        return b"TAR", None
+
+
+class _UnreachableClient:
+    """COA + export both unavailable → verdict must be 'unknown', not 'pass'."""
+    def _coa_get(self, path, params=None):
+        return None, "Connection error: could not reach COA endpoint."
+    def get(self, path, params=None):
+        if path == "playbook":
+            return {"data": [{"id": 1}]}, None
+        return None, "Connection error: could not reach SOAR REST API."
+    def get_binary(self, path, params=None):
+        return None, "Connection error."
+
+
+def _cfg():
+    c = McpServerConfig()
+    c.enabled_tools = set(READ_ONLY_TOOLS)
+    c.advisory_disclaimer = False
+    return c
+
+
+class AuditTest(unittest.TestCase):
+    def test_registered_read_only(self):
+        from soar_mcp_tools import TOOL_SCHEMAS, _TOOL_HANDLERS
+        self.assertIn("audit_visual_playbook", TOOL_SCHEMAS)
+        self.assertIn("audit_visual_playbook", _TOOL_HANDLERS)
+        self.assertIn("audit_visual_playbook", READ_ONLY_TOOLS)
+
+    def test_healthy_playbook_passes(self):
+        out = call_tool("audit_visual_playbook",
+                        {"playbook_id": 1, "output_format": "json"}, _HealthyClient(), _cfg())
+        d = json.loads(out)
+        self.assertIn(d["data"]["verdict"], ("pass", "warn"))
+        self.assertEqual(d["data"]["node_count"], 6)
+        self.assertTrue(d["data"]["capabilities"]["coa_graph_extractable"])
+        self.assertTrue(d["data"]["recommendations"])
+
+    def test_unreachable_is_unknown_not_pass(self):
+        out = call_tool("audit_visual_playbook",
+                        {"playbook_id": 1, "output_format": "json"}, _UnreachableClient(), _cfg())
+        d = json.loads(out)
+        self.assertEqual(d["data"]["verdict"], "unknown")
+        self.assertFalse(d["ok"])
+        self.assertTrue(any("cannot audit" in r for r in d["data"]["recommendations"]))
+
+    def test_never_claims_safe_when_python_unknown(self):
+        client = _HealthyClient()
+        client.get_binary = lambda p, params=None: (None, "404")
+        client.get = lambda p, params=None: (
+            ({"data": [{"id": 1}]}, None) if p == "playbook"
+            else ({"id": 1, "passed_validation": True}, None)  # no python field
+        )
+        out = call_tool("audit_visual_playbook",
+                        {"playbook_id": 1, "output_format": "json"}, client, _cfg())
+        d = json.loads(out)
+        # python unknown → at least 'warn', never a clean 'pass'
+        self.assertIn(d["data"]["verdict"], ("warn", "unknown", "fail"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_tools.py`, `soar_mcp_config.py`, `soar_mcp_server.json`, `test_soar_mcp_audit.py`
- **Scope:** neues read-only `audit_visual_playbook` Tool
- **Was bleibt unangetastet:** `check_visual_editor_compat`/`get_playbook_coa_summary` (additiv wiederverwendet, nicht geändert)

## Issue #69 (Phase 3)
Ein-Call-Pre-Edit-Audit: COA-Summary + Compat-Aggregator + Capability-Detection (#68) → severity-getaggter Audit mit Operator-Empfehlungen. **Verdict pass/warn/fail/UNKNOWN** — verspricht **nie** "safe to edit", wenn COA/Export unavailable oder Python nicht inspizierbar (konsumiert #68 für die ehrliche Unterscheidung).

## Verifikation
- `py_compile` + Manifest valide
- `unittest discover`: **75 Tests, OK** (71 + 4 neu)
- Kernabsicherung: unreachable → `unknown` (nie `pass`); python unknown → mind. `warn`

Closes #69. 🤖 Generated with [Claude Code](https://claude.com/claude-code)