### PR TITLE
feat: capability caching + graceful degradation (#68 part 2)

### DIFF
--- a/soar_mcp_capabilities.py
+++ b/soar_mcp_capabilities.py
@@ -18,6 +18,8 @@ Copyright 2026 Andreas Buis
 """
 from __future__ import annotations
 
+import threading
+import time
 from dataclasses import asdict, dataclass, field
 from typing import Any, Optional
 
@@ -109,3 +111,42 @@ def detect_capabilities(client, sample_playbook_id: int) -> CapabilityReport:
         report.validation_method = "passed_validation_flag"
 
     return report
+
+
+# ── Per-process cached accessor (issue #68 part 2) ────────────────────────────
+# Detection issues 3 read-only probes; caching avoids re-probing on every COA
+# tool call within a short window. Per-process only (like the rate limiter).
+
+_cache: dict[str, tuple[CapabilityReport, float]] = {}
+_cache_lock = threading.Lock()
+
+
+def get_capabilities(client, sample_playbook_id: int, *, ttl: float = 300.0) -> CapabilityReport:
+    """Cached capability detection, keyed on the client base URL + sample id."""
+    key = f"{getattr(client, '_base_url', '')}|{sample_playbook_id}"
+    now = time.time()
+    with _cache_lock:
+        hit = _cache.get(key)
+        if hit and hit[1] > now:
+            return hit[0]
+    report = detect_capabilities(client, sample_playbook_id)
+    with _cache_lock:
+        _cache[key] = (report, now + ttl)
+    return report
+
+
+def explain_empty_graph(client, playbook_id: int) -> Optional[dict]:
+    """When a tool gets an empty node/edge graph, return a capability-based
+    finding explaining WHY (instead of a silent 0), or None if a graph is
+    actually available (so the emptiness is genuine, not a capability gap)."""
+    caps = get_capabilities(client, playbook_id)
+    if caps.coa_graph_extractable or caps.export_fallback_available:
+        return None
+    if not caps.coa_endpoint_available:
+        msg = ("COA endpoint is unreachable and no export fallback is available — "
+               "the graph could not be retrieved (not necessarily empty).")
+    else:
+        msg = ("COA endpoint responded but no extractable node graph was found and "
+               "the export fallback is unavailable — graph could not be retrieved.")
+    return {"severity": "warn", "code": "graph_unavailable",
+            "source": "capabilities", "message": msg}

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -2949,8 +2949,17 @@ def tool_list_playbook_nodes(
     # Sort by y, x, id
     node_records.sort(key=lambda r: (r.get("y") or 0, r.get("x") or 0, r.get("id") or 0))
 
+    # Capability-aware degradation (#68 part 2): if the graph came back empty,
+    # explain WHY (COA/export unavailable) instead of a silent "0 nodes".
+    findings: list[dict] = []
+    if not nodes:
+        from soar_mcp_capabilities import explain_empty_graph
+        reason = explain_empty_graph(client, current_id)
+        if reason:
+            findings.append(reason)
+
     result = {
-        "ok": True,
+        "ok": bool(nodes) or not findings,
         "summary": f"{len(node_records)} node(s) in playbook {current_id}.",
         "data": {
             "input_id": pid,
@@ -2960,7 +2969,7 @@ def tool_list_playbook_nodes(
             "filtered_nodes": len(node_records),
             "nodes": node_records,
         },
-        "findings": [],
+        "findings": findings,
         "errors": errors,
     }
     return json.dumps(result, indent=2)
@@ -3015,8 +3024,16 @@ def tool_list_playbook_edges(
         r.get("id") or 0,
     ))
 
+    # Capability-aware degradation (#68 part 2): explain an empty edge graph.
+    findings: list[dict] = []
+    if not edges:
+        from soar_mcp_capabilities import explain_empty_graph
+        reason = explain_empty_graph(client, current_id)
+        if reason:
+            findings.append(reason)
+
     result = {
-        "ok": True,
+        "ok": bool(edges) or not findings,
         "summary": f"{len(edge_records)} edge(s) in playbook {current_id}.",
         "data": {
             "input_id": pid,
@@ -3026,7 +3043,7 @@ def tool_list_playbook_edges(
             "filtered_edges": len(edge_records),
             "edges": edge_records,
         },
-        "findings": [],
+        "findings": findings,
         "errors": errors,
     }
     return json.dumps(result, indent=2)

--- a/test_soar_mcp_capability_consumers.py
+++ b/test_soar_mcp_capability_consumers.py
@@ -1,0 +1,115 @@
+"""Tests for capability caching + consumer integration (issue #68 part 2)."""
+from __future__ import annotations
+
+import json
+import unittest
+
+import soar_mcp_capabilities as caps_mod
+from soar_mcp_capabilities import explain_empty_graph, get_capabilities
+from soar_mcp_config import READ_ONLY_TOOLS, McpServerConfig
+from soar_mcp_tools import call_tool
+
+
+class _CountingClient:
+    """Healthy client with an extractable COA graph; counts probe calls."""
+    def __init__(self, base="https://s/rest", nodes=3):
+        self._base_url = base
+        self._nodes = nodes
+        self.coa_calls = 0
+
+    def _coa_get(self, path, params=None):
+        self.coa_calls += 1
+        return {
+            "id": 1, "current_id": 1,
+            "coa_data": {
+                "nodes": {str(i): {"data": {"functionName": f"n{i}", "type": "action"}}
+                          for i in range(self._nodes)},
+                "edges": [{"source": "0", "target": "1"}],
+            },
+        }, None
+
+    def get(self, path, params=None):
+        if path.startswith("playbook/"):
+            return {"id": 1, "passed_validation": True, "python": "x=1\n"}, None
+        return {}, None
+
+    def get_binary(self, path, params=None):
+        return b"TAR", None
+
+
+class _NoGraphClient:
+    def __init__(self, base="https://n/rest"):
+        self._base_url = base
+    def _coa_get(self, path, params=None):
+        return None, "Connection error: could not reach COA endpoint."
+    def get(self, path, params=None):
+        return None, "Connection error."
+    def get_binary(self, path, params=None):
+        return None, "404"
+
+
+def _cfg():
+    c = McpServerConfig()
+    c.enabled_tools = set(READ_ONLY_TOOLS)
+    return c
+
+
+class CacheTest(unittest.TestCase):
+    def setUp(self):
+        caps_mod._cache.clear()
+
+    def test_get_capabilities_caches(self):
+        c = _CountingClient()
+        r1 = get_capabilities(c, 1)
+        calls_after_first = c.coa_calls
+        r2 = get_capabilities(c, 1)
+        self.assertIs(r1, r2)                    # same cached object
+        self.assertEqual(c.coa_calls, calls_after_first)  # no re-probe
+
+    def test_cache_expires(self):
+        c = _CountingClient()
+        get_capabilities(c, 1, ttl=0.0)          # immediately stale
+        first = c.coa_calls
+        get_capabilities(c, 1, ttl=0.0)
+        self.assertGreater(c.coa_calls, first)   # re-probed
+
+
+class ExplainTest(unittest.TestCase):
+    def setUp(self):
+        caps_mod._cache.clear()
+
+    def test_explain_none_when_graph_available(self):
+        self.assertIsNone(explain_empty_graph(_CountingClient(), 1))
+
+    def test_explain_finding_when_no_graph(self):
+        f = explain_empty_graph(_NoGraphClient(), 1)
+        self.assertIsNotNone(f)
+        self.assertEqual(f["code"], "graph_unavailable")
+
+
+class ConsumerTest(unittest.TestCase):
+    def setUp(self):
+        caps_mod._cache.clear()
+
+    def test_healthy_nodes_no_finding(self):
+        out = call_tool("list_playbook_nodes", {"playbook_id": 1}, _CountingClient(nodes=3), _cfg())
+        d = json.loads(out)
+        self.assertEqual(d["data"]["total_nodes_in_coa"], 3)
+        self.assertEqual(d["findings"], [])
+        self.assertTrue(d["ok"])
+
+    def test_empty_graph_gets_capability_finding(self):
+        out = call_tool("list_playbook_nodes", {"playbook_id": 1}, _NoGraphClient(), _cfg())
+        d = json.loads(out)
+        self.assertEqual(d["data"]["total_nodes_in_coa"], 0)
+        self.assertTrue(any(f["code"] == "graph_unavailable" for f in d["findings"]))
+        self.assertFalse(d["ok"])
+
+    def test_empty_edges_gets_capability_finding(self):
+        out = call_tool("list_playbook_edges", {"playbook_id": 1}, _NoGraphClient(), _cfg())
+        d = json.loads(out)
+        self.assertTrue(any(f["code"] == "graph_unavailable" for f in d["findings"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_capabilities.py`, `soar_mcp_tools.py`, `test_soar_mcp_capability_consumers.py`
- **Scope:** `get_capabilities` (Cache), `explain_empty_graph`, `list_playbook_nodes`/`list_playbook_edges` (nur Empty-Path)
- **Was bleibt unangetastet:** `_get_coa_nodes_edges`/`_select_playbook_python`/`_resolve_current_id` (live-verifiziert, chirurgisch unberührt)

## Issue #68 — Teil 2 (Abschluss)
- Per-Prozess-TTL-Cache für die Capability-Detection (kein Re-Probing pro Call)
- `explain_empty_graph`: capability-basierter Grund bei leerem Graph
- Node/Edge-List-Tools melden **warum** ein Graph leer ist (`graph_unavailable` + `ok=false`) statt still 0

## Sicherheit / Design
Bewusst chirurgisch: nur der Failure-Path wird angereichert, die Extraktions-Helfer bleiben unberührt → keine Regression der gerade restabilisierten COA-Pfade. Happy-Path per Test bestätigt.

## Verifikation
- `py_compile`: OK
- `unittest discover`: **82 Tests, OK** (75 + 7 neu) — inkl. Cache-Hit/Expiry, Happy-Path-Regression, Empty→Finding

Closes #68. 🤖 Generated with [Claude Code](https://claude.com/claude-code)