### PR TITLE
fix: hide unverified save_playbook_layout_only from tools/list (#65 interim)

### DIFF
--- a/soar_mcp_handler.py
+++ b/soar_mcp_handler.py
@@ -300,6 +300,14 @@ class SoarMcpRestHandler(dict):
             "instructions": instructions,
         }
 
+    # Tools whose real function is not yet available on any verified SOAR
+    # version, so they must NOT be advertised in tools/list as functional
+    # (issue #65). save_playbook_layout_only can only preview (dry_run); its
+    # actual write path is blocked until the COA write endpoint is live-verified
+    # (see VERIFICATION.md). Hidden from discovery; a direct dry_run call is
+    # still honoured by _handle_tools_call for anyone who already knows the name.
+    _HIDDEN_FROM_LIST = frozenset({"save_playbook_layout_only"})
+
     def _handle_tools_list(self, config: McpServerConfig,
                            token_verification=None) -> dict:
         # Scoped token allow-list intersects with asset-config enabled tools.
@@ -311,7 +319,7 @@ class SoarMcpRestHandler(dict):
             {"name": name, "description": schema["description"],
              "inputSchema": schema["inputSchema"]}
             for name, schema in TOOL_SCHEMAS.items()
-            if name in allowed
+            if name in allowed and name not in self._HIDDEN_FROM_LIST
         ]
         logger.info("[SOAR MCP] tools/list → %d tools", len(tools))
         return {"tools": tools}

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -322,7 +322,7 @@
             "order": 80
         },
         "tool_save_playbook_layout_only": {
-            "description": "WRITE \u26a0\ufe0f \u2014 save_playbook_layout_only: Save node x/y positions to VPE. dry_run=true (default) is always safe. Actual write is blocked until COA write endpoint is verified in VERIFICATION.md.",
+            "description": "WRITE \u26a0\ufe0f (PREVIEW ONLY) \u2014 save_playbook_layout_only: Save node x/y positions to VPE. The actual write path is unverified and blocked, so this tool is HIDDEN from the MCP tools/list until the COA write endpoint is verified (VERIFICATION.md). dry_run preview still works if called directly. This checkbox currently has no effect on discovery.",
             "data_type": "boolean",
             "default": false,
             "required": false,

--- a/test_soar_mcp_hidden_tools.py
+++ b/test_soar_mcp_hidden_tools.py
@@ -1,0 +1,32 @@
+"""Tests for hiding unverified tools from tools/list (issue #65)."""
+from __future__ import annotations
+
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_handler import SoarMcpRestHandler
+
+
+def _handler():
+    # Bypass __init__ (which runs full request processing) — we only test one method.
+    return SoarMcpRestHandler.__new__(SoarMcpRestHandler)
+
+
+class HiddenToolsTest(unittest.TestCase):
+    def test_layout_write_hidden_even_when_enabled(self):
+        cfg = McpServerConfig()
+        cfg.enabled_tools = {"list_cases", "save_playbook_layout_only"}
+        result = _handler()._handle_tools_list(cfg)
+        names = {t["name"] for t in result["tools"]}
+        self.assertIn("list_cases", names)
+        self.assertNotIn("save_playbook_layout_only", names)
+
+    def test_other_tools_unaffected(self):
+        cfg = McpServerConfig()
+        cfg.enabled_tools = {"list_cases", "get_case", "detect_soar_capabilities"}
+        names = {t["name"] for t in _handler()._handle_tools_list(cfg)["tools"]}
+        self.assertEqual(names, {"list_cases", "get_case", "detect_soar_capabilities"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_handler.py`, `soar_mcp_server.json`, `test_soar_mcp_hidden_tools.py`
- **Scope:** `_HIDDEN_FROM_LIST` + `_handle_tools_list` Filter; Manifest-Beschreibung
- **Was bleibt unangetastet:** dry_run-Preview-Pfad (direkter Aufruf weiter möglich), alle anderen Tools

## Issue #65 — Interim
`save_playbook_layout_only` hat einen unverifizierten/geblockten Write-Pfad → wird jetzt **aus tools/list ausgeblendet**, damit es nicht als funktional beworben wird. Direkter dry_run-Preview bleibt möglich. Endgültige Aktivierung erst nach Live-Verifikation des COA-Write-Endpoints.

## Verifikation
- `py_compile` + Manifest valide
- `unittest discover`: **84 Tests, OK** — inkl. Test, dass das Tool auch bei aktivierter Checkbox nicht in tools/list erscheint und andere Tools unberührt bleiben

Closes #65. 🤖 Generated with [Claude Code](https://claude.com/claude-code)