### PR TITLE
feat: mcp.conf base_url trusted fallback + credential rejection (#93/#94)

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -43,6 +43,15 @@ timeout = 60.0
 # Default: 50
 max_results = 50
 
+# Trusted SOAR base URL for internal REST/COA calls (issue #93).
+# Only needed on SOAR builds where `phantom.rest` is not importable from the app
+# handler context (observed on 8.5.0.248) AND you prefer a static config over the
+# asset-config Base URL (which Test Connectivity persists to local/). Unlike
+# local/, a value here (in local/mcp.conf) is an explicit admin choice. Must be a
+# full https URL with no embedded credentials; request headers are NEVER used.
+# Default: (empty — resolved from phantom.rest or the asset config)
+# base_url = https://soar.example.com
+
 # SSL verification for outbound calls to the SOAR REST API.
 #   true   : Verify using system CA bundle (default, recommended for production)
 #   false  : Disable verification (use only in dev/test with self-signed certs)

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -38,6 +38,27 @@ def _manifest_app_version() -> str:
 # ── Valid values ───────────────────────────────────────────────────────────────
 _VALID_SEVERITIES = {"high", "medium", "low", "informational", ""}
 
+
+def normalise_base_url(raw: object) -> str:
+    """Return a trusted, scheme-qualified SOAR base URL without a trailing slash,
+    or "" if it is not usable. Rejects non-http(s) schemes and URLs with embedded
+    credentials (issue #93, contributed by @reisball). Strict on purpose: this is
+    an admin-configured value, so it must be a full, clean URL."""
+    if not isinstance(raw, str):
+        return ""
+    from urllib.parse import urlparse
+    val = raw.strip().rstrip("/")
+    if not val:
+        return ""
+    parsed = urlparse(val)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        logger.warning("[MCP Config] Ignoring invalid base_url '%s'.", val)
+        return ""
+    if parsed.username or parsed.password:
+        logger.warning("[MCP Config] Ignoring base_url with embedded credentials.")
+        return ""
+    return val
+
 # ── All known tool names ───────────────────────────────────────────────────────
 ALL_TOOLS: list[str] = [
     # Read-only
@@ -145,6 +166,9 @@ class McpServerConfig:
     # [server] section
     timeout: float = 60.0
     max_results: int = 50
+    # Trusted admin-configured SOAR base URL (mcp.conf [server] base_url). Used by
+    # the handler as a fallback when phantom.rest is unavailable (issue #93).
+    base_url: str = ""
     ssl_verify: Union[bool, str] = True
     log_tool_calls: bool = True
     protocol_version: str = "2024-11-05"
@@ -206,6 +230,7 @@ class McpServerConfig:
             "protocol_version": self.protocol_version,
             "server_name": self.server_name,
             "server_version": self.server_version,
+            "base_url_configured": bool(self.base_url),
             "ssl_verify": self.ssl_verify if isinstance(self.ssl_verify, bool) else "custom_path",
             "allowed_labels": self.allowed_labels,
             "min_severity": self.min_severity,
@@ -307,6 +332,10 @@ class McpConfigLoader:
         # ── [server] ──────────────────────────────────────────────────────────
         config.timeout = self._get_float(parser, "server", "timeout", 60.0, min_val=1.0, max_val=300.0)
         config.max_results = self._get_int(parser, "server", "max_results", 50, min_val=1, max_val=500)
+        config.base_url = normalise_base_url(
+            parser.get("server", "base_url", fallback="").strip()
+            or parser.get("server", "soar_base_url", fallback="").strip()
+        )
         config.ssl_verify = self._parse_ssl_verify(parser.get("server", "ssl_verify", fallback="true"))
         config.log_tool_calls = self._get_bool(parser, "server", "log_tool_calls", True)
         config.protocol_version = parser.get("server", "protocol_version", fallback="2024-11-05").strip()

--- a/soar_mcp_handler.py
+++ b/soar_mcp_handler.py
@@ -133,7 +133,7 @@ class SoarMcpRestHandler(dict):
         session_id = meta.get("HTTP_MCP_SESSION_ID", "")
 
         # Extract base URL from request for API callbacks
-        soar_base = self._extract_base_url(request)
+        soar_base = self._extract_base_url(request, config)
 
         # Persist asset name for widget
         asset_name = path_args[0] if path_args else ""
@@ -407,6 +407,11 @@ class SoarMcpRestHandler(dict):
         if not url:
             return ""
         url = url.strip().rstrip("/")
+        # Reject embedded credentials (user:pass@host) regardless of scheme (#93).
+        host_part = url.split("://", 1)[-1]
+        if "@" in host_part.split("/", 1)[0]:
+            logger.warning("[SOAR MCP] Ignoring base_url with embedded credentials.")
+            return ""
         if re.match(r"^https?://", url, re.I):
             return url
         if "://" not in url:
@@ -427,19 +432,20 @@ class SoarMcpRestHandler(dict):
         return ""
 
     @staticmethod
-    def _extract_base_url(request) -> str:
+    def _extract_base_url(request, config=None) -> str:
         # Security (issue #58): the returned base_url is used to build the
         # SoarApiClient that sends the SOAR call token. It must come from a
         # TRUSTED source, NEVER from attacker-controllable request headers
         # (Host / X-Forwarded-*), which could redirect token-bearing API calls
         # to an attacker host (SSRF/credential exfil).
         #
-        # 1. phantom.rest.get_phantom_base_url() — authoritative on-box.
-        # 2. Operator-configured base_url from the asset config (trusted).
-        #    Restores resilience when phantom.rest is unavailable on a given
-        #    request (issue: MissingSchema on export/nodes/validate) WITHOUT
-        #    trusting request headers.
-        # Fail closed ("") if neither yields a scheme-qualified URL.
+        # Trusted sources, in order (all admin-controlled, never request headers):
+        #   1. phantom.rest.get_phantom_base_url() — authoritative on-box.
+        #   2. mcp.conf [server] base_url — static admin config, survives across
+        #      reinstalls better than local/ (issue #93, contributed by @reisball).
+        #   3. asset-config base_url persisted to local/asset_overrides.json by
+        #      Test Connectivity.
+        # Fail closed ("") if none yields a scheme-qualified URL.
         cls = SoarMcpRestHandler
         try:
             import phantom.rest as _pr
@@ -448,11 +454,15 @@ class SoarMcpRestHandler(dict):
                 return url
         except Exception:
             pass
+        if config is not None and getattr(config, "base_url", ""):
+            url = cls._normalize_base_url(config.base_url)
+            if url:
+                return url
         url = cls._normalize_base_url(cls._read_configured_base_url())
         if url:
             return url
-        logger.warning("[SOAR MCP] Could not resolve SOAR base URL from phantom.rest "
-                       "or asset config; refusing to derive it from request headers.")
+        logger.warning("[SOAR MCP] Could not resolve SOAR base URL from phantom.rest, "
+                       "mcp.conf, or asset config; refusing to derive it from request headers.")
         return ""
 
     @staticmethod

--- a/test_soar_mcp_base_url.py
+++ b/test_soar_mcp_base_url.py
@@ -64,6 +64,31 @@ class BaseUrlResolutionTest(unittest.TestCase):
         H._extract_base_url(object())
         self.assertTrue(captured.get("called"))
 
+    def test_mcp_conf_base_url_used_when_phantom_unavailable(self):
+        # #93 / #94: config.base_url (mcp.conf [server] base_url) is a trusted
+        # fallback, preferred over the asset-override file.
+        H._read_configured_base_url = staticmethod(lambda: "")
+
+        class _Cfg:
+            base_url = "https://from-mcp-conf.example.com"
+
+        self.assertEqual(H._extract_base_url(object(), _Cfg()),
+                         "https://from-mcp-conf.example.com")
+
+
+class BaseUrlCredentialTest(unittest.TestCase):
+    """Embedded credentials in a base_url must be rejected (issue #93/#94)."""
+
+    def test_handler_normalize_rejects_credentials(self):
+        self.assertEqual(H._normalize_base_url("https://user:pass@soar.x"), "")
+
+    def test_config_normalise_rejects_credentials_and_bad_scheme(self):
+        from soar_mcp_config import normalise_base_url
+        self.assertEqual(normalise_base_url("https://user:pass@soar.x"), "")
+        self.assertEqual(normalise_base_url("ftp://soar.x"), "")
+        self.assertEqual(normalise_base_url("soar.x"), "")   # strict: scheme required
+        self.assertEqual(normalise_base_url("https://soar.x/"), "https://soar.x")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_config.py`, `soar_mcp_handler.py`, `default/mcp.conf`, `test_soar_mcp_base_url.py`
- **Scope:** `normalise_base_url`, `config.base_url` (mcp.conf), `_extract_base_url` (zusätzliche trusted Quelle), Credential-Ablehnung
- **Was bleibt unangetastet:** kein Request-Header-Fallback (#58 gewahrt), Auth/Token/REST-Client

## Kontext
Übernimmt das **Mehrwert-Delta aus @reisball's PR #94** auf aktuellem main (der Kern-Fix für #93 ist bereits in v1.9.1). Neu:
- **`[server] base_url` / `soar_base_url` in mcp.conf** als trusted Quelle — persistenter als `local/`, überlebt Reinstalls besser
- **Credential-Ablehnung** (`user:pass@host`) in Config- **und** Handler-Normalisierung
- Reihenfolge: phantom.rest → mcp.conf base_url → asset_overrides → fail-closed

## Verifikation
- `unittest discover`: **91 Tests, OK** (inkl. mcp.conf-Quelle + Credential-Reject)
- pylint 3.13 E-Level (config+handler): 10.00/10

Ersetzt PR #94 (das gegen alten main konfliktete); Credit an @reisball. Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)