### PR TITLE
fix: persistent confirmation store + portable test-harness cleanup (#116 #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,25 @@ Write tools modify live SOAR data. Enable only after reviewing the [Disclaimer](
 
 | Tool | Action | Requirement |
 |------|--------|-------------|
-| **`create_container`** | Creates an isolated test container for playbook self-testing | Requires `enable_test_harness` checkbox **AND** SOAR user with container-creation rights |
+| **`create_container`** | Creates an isolated test container for playbook self-testing | `enable_test_harness` + SOAR user with **container-create** rights |
+| **`delete_container`** | Deletes a suite-owned test container (cleanup) | `enable_test_harness` + SOAR user with **container-delete** rights |
 
 Enable via asset config: check **`enable_test_harness`** → Save → Test Connectivity. No SSH or file edit required (v1.6.9+).
+
+**Required SOAR permissions for the full create → test → cleanup loop:** the token
+user needs create/update rights on containers, artifacts, and notes **and**
+container-**delete** rights for cleanup. A user with only *Automation /
+Automation Engineer* can typically create and mutate test containers but **cannot
+delete** them (delete returns HTTP 403) — grant a role with container-delete, or
+clean up test cases manually. `delete_container` reports a 403 as a clear cleanup
+finding, not a silent success.
+
+**Container label portability:** `test` is not a valid container label on every
+SOAR install. Set the label your instance actually allows (e.g. `events`) via
+`[safety] test_container_label` in `mcp.conf`; `create_container` uses it as the
+default. `delete_container` treats a container as suite-owned (safe to delete) if
+its label matches `test_container_label` **or** its name starts with
+`[safety] test_container_name_prefix` (default `mcp_`).
 
 ---
 

--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -248,8 +248,23 @@ enable_test_harness = false
 # Two-step commit for write tools (issue #50). When true, every write tool must
 # be called twice: the first call returns a confirm_token + preview, the second
 # (same args + token) executes. Enforces human-in-the-loop for AI-driven writes.
+# Confirmation tokens are persisted to local/pending_confirmations.json so they
+# survive across SOAR's multi-process handler (issue #116).
 # Default: false (backwards-compatible).
 require_confirmation = false
+
+# Test-harness container settings (issue #117). "test" is not a valid container
+# label on every SOAR install (some only allow e.g. "events"). Point this at a
+# label your instance actually has; create_container uses it as the default and
+# delete_container treats it as safe-to-delete.
+# Default: test
+test_container_label = test
+
+# delete_container also treats any container whose NAME starts with this prefix
+# as suite-owned (safe to delete), even if its label differs. Keeps automated
+# cleanup scoped to test objects.
+# Default: mcp_
+test_container_name_prefix = mcp_
 
 [tokens]
 # Scoped MCP token settings (v1.5.0+).

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -189,6 +189,11 @@ class McpServerConfig:
     # called twice: the first call returns a confirm_token, the second (with the
     # same args + token) executes. Default off = backwards-compatible.
     require_confirmation: bool = False
+    # Test-harness portability (issue #117). The default container label ("test")
+    # is not valid on every SOAR install; make it configurable. delete_container
+    # also treats a name starting with test_container_name_prefix as suite-owned.
+    test_container_label: str = "test"
+    test_container_name_prefix: str = "mcp_"
 
     # AI instructions — sent to the LLM in every MCP initialize response
     ai_instructions: str = ""
@@ -362,6 +367,10 @@ class McpConfigLoader:
         config.min_severity = raw_sev if raw_sev in _VALID_SEVERITIES else ""
         config.enable_test_harness = self._get_bool(parser, "safety", "enable_test_harness", False)
         config.require_confirmation = self._get_bool(parser, "safety", "require_confirmation", False)
+        config.test_container_label = (
+            parser.get("safety", "test_container_label", fallback="test").strip() or "test")
+        config.test_container_name_prefix = (
+            parser.get("safety", "test_container_name_prefix", fallback="mcp_").strip() or "mcp_")
 
         # ── [server] ai_instructions ───────────────────────────────────────────
         config.ai_instructions = parser.get("server", "ai_instructions", fallback="").strip()

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -1789,7 +1789,11 @@ def tool_create_container(client: SoarApiClient, config: McpServerConfig, args: 
     if not name:
         return "Error: name is required."
 
-    label = (args.get("label") or "test").strip()
+    # #117: "test" is not a valid container label on every SOAR install. Default
+    # to the configured test_container_label so operators can point it at a label
+    # their instance actually has (e.g. "events").
+    default_label = getattr(config, "test_container_label", "test") or "test"
+    label = (args.get("label") or default_label).strip()
     severity = (args.get("severity") or "low").strip().lower()
     if severity not in _VALID_SEVERITIES:
         severity = "low"
@@ -1838,22 +1842,40 @@ def tool_delete_container(client: SoarApiClient, config: McpServerConfig, args: 
     if err_msg:
         return err_msg
 
-    # Safety: refuse to delete a container that is not a recognisable test
-    # container unless the caller explicitly forces it. create_container writes
-    # a "test" label by default; require confirm=true to delete anything else.
+    # Safety (#117): a container counts as suite-owned (safe to delete) if its
+    # label matches the configured test label OR its name starts with the
+    # configured test-name prefix (e.g. "mcp_"). This works even where the label
+    # isn't literally "test". Anything else needs confirm=true.
     confirm = bool(args.get("confirm", False))
+    test_label = (getattr(config, "test_container_label", "test") or "test").lower()
+    name_prefix = getattr(config, "test_container_name_prefix", "mcp_") or "mcp_"
     existing, _ = client.get(f"container/{container_id}")
     if isinstance(existing, dict):
         label = (existing.get("label") or "").lower()
-        if label != "test" and not confirm:
+        cname = existing.get("name") or ""
+        suite_owned = (label == test_label) or cname.startswith(name_prefix)
+        if not suite_owned and not confirm:
             return (
-                f"Refusing to delete container #{container_id}: its label is "
-                f"'{existing.get('label') or 'none'}', not 'test'. This does not look "
-                "like an MCP test container. Re-call with confirm=true if you are sure."
+                f"Refusing to delete container #{container_id}: label "
+                f"'{existing.get('label') or 'none'}' != configured test label "
+                f"'{test_label}' and name does not start with '{name_prefix}'. This does "
+                "not look like an MCP test container. Re-call with confirm=true if you "
+                "are sure, or set [safety] test_container_label / "
+                "test_container_name_prefix to match your test objects."
             )
 
     data, err = client.delete(f"container/{container_id}")
     if err:
+        # #117: a create/update-capable token often still lacks delete permission.
+        # Surface it as an actionable cleanup/permission finding, not a silent fail.
+        if "403" in str(err):
+            return (
+                f"Cleanup incomplete — could not delete container #{container_id}: {err}\n"
+                "The token user can create/update containers but lacks delete permission. "
+                "Grant a role with container-delete rights, or clean up this test "
+                "container manually. Required roles for the full create→test→cleanup "
+                "loop are documented in the README (Test Harness)."
+            )
         return f"Error deleting container {container_id}: {err}"
 
     return (
@@ -4212,8 +4234,9 @@ TOOL_SCHEMAS["audit_visual_playbook"] = {
 TOOL_SCHEMAS["delete_container"] = {
     "description": (
         "WRITE — Delete a test container by ID to clean up after playbook self-tests. "
-        "Requires the test harness to be enabled. Refuses to delete containers not "
-        "labelled 'test' unless confirm=true. Never use on production."
+        "Requires the test harness to be enabled. Only deletes suite-owned test "
+        "containers (matching the configured test label or name prefix) unless "
+        "confirm=true. Never use on production."
     ),
     "inputSchema": {
         "type": "object",
@@ -4286,39 +4309,85 @@ _WRITE_TOOLS: frozenset[str] = frozenset(_TOOL_HANDLERS) - READ_ONLY_TOOLS
 
 
 class _ConfirmStore:
-    """In-process, TTL-bound confirmation tokens keyed on (tool, args).
+    """File-backed, TTL-bound confirmation tokens keyed on (tool, args).
 
-    Per-process only (like the token rate limiter); a confirm token issued on
-    one worker is not valid on another. That is acceptable — worst case the
-    client is asked to confirm again.
+    Issue #116: SOAR's REST handler runs multi-process, so an in-memory store
+    issued the token in one worker and never found it in the next — confirmed
+    writes could never execute. This store persists pending confirmations to
+    local/pending_confirmations.json so the token survives across handler
+    processes. Only a SHA-256 hash of the token is stored, never the raw token.
     """
 
-    def __init__(self) -> None:
-        self._d: dict[str, tuple[str, float]] = {}
+    def __init__(self, path=None) -> None:
+        import os as _os
+        app_dir = _os.path.dirname(_os.path.abspath(__file__))
+        self._path = path or _os.path.join(app_dir, "local", "pending_confirmations.json")
         self._lock = threading.Lock()
 
     @staticmethod
-    def _key(tool: str, args: dict) -> str:
+    def _args_hash(tool: str, args: dict) -> str:
         blob = tool + "|" + json.dumps(args, sort_keys=True, default=str)
         return hashlib.sha256(blob.encode()).hexdigest()
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    def _load(self) -> dict:
+        import os as _os
+        try:
+            if _os.path.exists(self._path):
+                with open(self._path, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                    return data if isinstance(data, dict) else {}
+        except Exception:
+            pass
+        return {}
+
+    def _save(self, data: dict) -> None:
+        import os as _os
+        try:
+            _os.makedirs(_os.path.dirname(self._path), exist_ok=True)
+            tmp = self._path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            _os.replace(tmp, self._path)
+            try:
+                _os.chmod(self._path, 0o600)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    @staticmethod
+    def _prune(data: dict) -> dict:
+        now = time.time()
+        return {k: v for k, v in data.items()
+                if isinstance(v, list) and len(v) == 3 and v[2] > now}
 
     def issue(self, tool: str, args: dict, ttl: float = 300.0) -> str:
         token = "confirm_" + secrets.token_urlsafe(9)
         with self._lock:
-            self._d[token] = (self._key(tool, args), time.time() + ttl)
+            data = self._prune(self._load())
+            data[self._token_hash(token)] = [tool, self._args_hash(tool, args), time.time() + ttl]
+            self._save(data)
         return token
 
     def consume(self, token: str, tool: str, args: dict) -> bool:
+        th = self._token_hash(str(token))
         with self._lock:
-            entry = self._d.get(token)
-            if not entry:
-                return False
-            key, exp = entry
-            if time.time() > exp or key != self._key(tool, args):
-                self._d.pop(token, None)
-                return False
-            self._d.pop(token, None)
-            return True
+            data = self._load()
+            entry = data.get(th)
+            data = self._prune(data)          # drop expired (incl. possibly this one)
+            ok = False
+            if (isinstance(entry, list) and len(entry) == 3
+                    and entry[2] > time.time()
+                    and entry[0] == tool
+                    and entry[1] == self._args_hash(tool, args)):
+                ok = True
+            data.pop(th, None)                 # single-use: always remove on match/attempt
+            self._save(data)
+            return ok
 
 
 _confirm_store = _ConfirmStore()

--- a/test_soar_mcp_confirm_and_harness.py
+++ b/test_soar_mcp_confirm_and_harness.py
@@ -1,0 +1,118 @@
+"""Tests for #116 (persistent confirmation store) and #117 (harness portability)."""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from soar_mcp_config import McpServerConfig, READ_ONLY_TOOLS
+from soar_mcp_tools import _ConfirmStore, call_tool
+
+
+class ConfirmStorePersistenceTest(unittest.TestCase):
+    """#116: a token issued by one 'process' must be consumable by another."""
+
+    def setUp(self):
+        fd, self.path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        os.unlink(self.path)  # start absent
+
+    def tearDown(self):
+        for p in (self.path, self.path + ".tmp"):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+    def test_token_survives_across_store_instances(self):
+        # Two separate _ConfirmStore instances on the same file simulate two
+        # SOAR handler worker processes.
+        issuer = _ConfirmStore(self.path)
+        consumer = _ConfirmStore(self.path)
+        args = {"name": "x", "label": "events"}
+        token = issuer.issue("create_container", args)
+        self.assertTrue(consumer.consume(token, "create_container", args))
+
+    def test_single_use(self):
+        s1, s2 = _ConfirmStore(self.path), _ConfirmStore(self.path)
+        args = {"a": 1}
+        tok = s1.issue("run_playbook", args)
+        self.assertTrue(s2.consume(tok, "run_playbook", args))
+        self.assertFalse(_ConfirmStore(self.path).consume(tok, "run_playbook", args))
+
+    def test_changed_args_fail(self):
+        s = _ConfirmStore(self.path)
+        tok = s.issue("run_playbook", {"case_id": 1})
+        self.assertFalse(_ConfirmStore(self.path).consume(tok, "run_playbook", {"case_id": 2}))
+
+    def test_expired_fail(self):
+        s = _ConfirmStore(self.path)
+        tok = s.issue("run_playbook", {"a": 1}, ttl=0.0)
+        self.assertFalse(_ConfirmStore(self.path).consume(tok, "run_playbook", {"a": 1}))
+
+    def test_raw_token_not_stored(self):
+        s = _ConfirmStore(self.path)
+        tok = s.issue("run_playbook", {"a": 1})
+        with open(self.path, encoding="utf-8") as fh:
+            content = fh.read()
+        self.assertNotIn(tok, content)  # only the hash is persisted
+
+
+class _FakeContainerClient:
+    def __init__(self, label="events", name="mcp_write_suite_1", delete_err=None):
+        self._label = label
+        self._name = name
+        self._delete_err = delete_err
+        self.deleted = False
+
+    def get(self, path, params=None):
+        return {"id": 3, "label": self._label, "name": self._name}, None
+
+    def delete(self, path):
+        if self._delete_err:
+            return None, self._delete_err
+        self.deleted = True
+        return {"success": True}, None
+
+
+def _harness_cfg(**over):
+    c = McpServerConfig()
+    c.enable_test_harness = True
+    c.advisory_disclaimer = False
+    c.enabled_tools = set(READ_ONLY_TOOLS) | {"delete_container"}
+    for k, v in over.items():
+        setattr(c, k, v)
+    return c
+
+
+class DeleteContainerPortabilityTest(unittest.TestCase):
+    """#117: suite-owned detection by configured label OR name prefix."""
+
+    def test_delete_by_name_prefix_even_if_label_differs(self):
+        client = _FakeContainerClient(label="events", name="mcp_write_suite_1")
+        out = call_tool("delete_container", {"container_id": 3}, client, _harness_cfg())
+        self.assertTrue(client.deleted, out)
+        self.assertIn("deleted", out)
+
+    def test_delete_by_configured_label(self):
+        client = _FakeContainerClient(label="events", name="something_else")
+        out = call_tool("delete_container", {"container_id": 3}, client,
+                        _harness_cfg(test_container_label="events"))
+        self.assertTrue(client.deleted, out)
+
+    def test_refuses_non_suite_container(self):
+        client = _FakeContainerClient(label="production", name="real_case")
+        out = call_tool("delete_container", {"container_id": 3}, client, _harness_cfg())
+        self.assertFalse(client.deleted)
+        self.assertIn("Refusing to delete", out)
+
+    def test_403_is_actionable_cleanup_finding(self):
+        client = _FakeContainerClient(
+            name="mcp_x", delete_err="Access denied (HTTP 403). Not authorized.")
+        out = call_tool("delete_container", {"container_id": 3}, client, _harness_cfg())
+        self.assertIn("Cleanup incomplete", out)
+        self.assertIn("delete permission", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Behobene Issues (reisball, live auf 8.5.0.248 verifiziert)

### #116 — bestätigte Writes wurden nie ausgeführt
**Root Cause:** `_ConfirmStore` war In-Memory; SOARs Handler ist multi-process → Token aus Worker A unsichtbar in Worker B → `consume` scheiterte immer.
**Fix:** file-backed Store (`local/pending_confirmations.json`) — atomic write + chmod 600, nur **Token-Hash** gespeichert, Single-Use, TTL. Überlebt Prozessgrenzen.

### #117 — Test-Harness-Cleanup nicht portabel
- `create_container`-Default-Label jetzt konfigurierbar (`[safety] test_container_label`) statt hartem `test`
- `delete_container` erkennt suite-eigene Container per **Label ODER Name-Präfix** (`test_container_name_prefix`, default `mcp_`)
- 403 beim Delete → **aktionable Cleanup-Meldung** statt stiller Fehlschlag
- README: benötigte SOAR-Rollen + Label/Präfix-Policy dokumentiert

## Verifikation
- `unittest discover`: **100 Tests, OK** — inkl. **Multi-Prozess-Simulation** (Token aus einer Store-Instanz von einer zweiten konsumiert), Single-Use, Expiry, Changed-Args, „Rohtoken nicht gespeichert"; #117 Label/Präfix/403-Pfade
- pylint 3.13 E-Level: 10.00/10

Closes #116, closes #117. Co-authored mit @reisball. 🤖 Generated with [Claude Code](https://claude.com/claude-code)