### PR TITLE
docs: version-neutral doc headers

### DIFF
--- a/LIVE_TOOLS.md
+++ b/LIVE_TOOLS.md
@@ -1,4 +1,4 @@
-# SOAR MCP Server — Live Tools (v1.11.6)
+# SOAR MCP Server — Live Tools
 
 **40 tools total: 30 read-only (enabled by default) + 10 write (off by default).**
 Availability is controlled per-tool via the asset configuration checkboxes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SOAR MCP Server
 
-**Splunk SOAR On-Premises App — v1.11.6** · runs on **Python 3.13**
+**Splunk SOAR On-Premises App** · runs on **Python 3.13** · [latest release](https://github.com/abuis78/soar_mcp_server/releases/latest)
 
 Transform Splunk SOAR into an MCP (Model Context Protocol) server endpoint for direct AI integration. Claude Desktop, Claude Code, Claude.ai, or any MCP-compatible AI client can connect directly to your SOAR instance for structured access to cases, artifacts, playbooks, and analyst notes — completely on-premises, with zero external dependencies.
 


### PR DESCRIPTION
Removes the pinned patch version from the README/LIVE_TOOLS headers so they don't drift each release. No release needed — ships with the next code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)