### PR TITLE
fix: delete_container fail-safe on container GET failure (#126)

### DIFF
--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -1849,8 +1849,17 @@ def tool_delete_container(client: SoarApiClient, config: McpServerConfig, args: 
     confirm = bool(args.get("confirm", False))
     test_label = (getattr(config, "test_container_label", "test") or "test").lower()
     name_prefix = getattr(config, "test_container_name_prefix", "mcp_") or "mcp_"
-    existing, _ = client.get(f"container/{container_id}")
-    if isinstance(existing, dict):
+    existing, get_err = client.get(f"container/{container_id}")
+    if not isinstance(existing, dict):
+        # #126: fail-safe — if we cannot READ the container we cannot verify it is
+        # a test container, so refuse to delete unless the caller forces it.
+        if not confirm:
+            return (
+                f"Refusing to delete container #{container_id}: could not read it to "
+                f"verify it is a test container ({get_err or 'unexpected response'}). "
+                "Re-call with confirm=true if you are sure it is safe to delete."
+            )
+    else:
         label = (existing.get("label") or "").lower()
         cname = existing.get("name") or ""
         suite_owned = (label == test_label) or cname.startswith(name_prefix)

--- a/test_soar_mcp_confirm_and_harness.py
+++ b/test_soar_mcp_confirm_and_harness.py
@@ -59,13 +59,17 @@ class ConfirmStorePersistenceTest(unittest.TestCase):
 
 
 class _FakeContainerClient:
-    def __init__(self, label="events", name="mcp_write_suite_1", delete_err=None):
+    def __init__(self, label="events", name="mcp_write_suite_1", delete_err=None,
+                 get_err=None):
         self._label = label
         self._name = name
         self._delete_err = delete_err
+        self._get_err = get_err
         self.deleted = False
 
     def get(self, path, params=None):
+        if self._get_err:
+            return None, self._get_err
         return {"id": 3, "label": self._label, "name": self._name}, None
 
     def delete(self, path):
@@ -112,6 +116,19 @@ class DeleteContainerPortabilityTest(unittest.TestCase):
         out = call_tool("delete_container", {"container_id": 3}, client, _harness_cfg())
         self.assertIn("Cleanup incomplete", out)
         self.assertIn("delete permission", out)
+
+    def test_get_failure_refuses_delete_without_confirm(self):
+        # #126: if the container GET fails, do NOT delete (fail-safe).
+        client = _FakeContainerClient(get_err="Resource not found (HTTP 404).")
+        out = call_tool("delete_container", {"container_id": 3}, client, _harness_cfg())
+        self.assertFalse(client.deleted, out)
+        self.assertIn("could not read it", out)
+
+    def test_get_failure_allows_delete_with_confirm(self):
+        client = _FakeContainerClient(get_err="Connection error.")
+        out = call_tool("delete_container", {"container_id": 3, "confirm": True},
+                        client, _harness_cfg())
+        self.assertTrue(client.deleted, out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change-Contract
- **Dateien:** `soar_mcp_tools.py`, `test_soar_mcp_confirm_and_harness.py`
- **Scope:** `tool_delete_container` — Guard bei nicht-lesbarem Container
- **Was bleibt unangetastet:** übrige delete-Logik, alle anderen Tools

## Behobenes Issue — #126 (Selbst-Audit-Fund)
Schlug `client.get(container/{id})` fehl (`existing` kein Dict), wurde der suite-owned-Check komplett übersprungen und **ohne Prüfung gelöscht**. Jetzt: bei nicht lesbarem Container **Ablehnung**, außer `confirm=true`.

## Verifikation
- `py_compile`: OK
- Neue Tests: GET-Fehler ohne confirm → **kein** Delete + „could not read it"; mit confirm → Delete
- `unittest discover`: **104 Tests, OK**

Closes #126. 🤖 Generated with [Claude Code](https://claude.com/claude-code)