### PR TITLE
fix: ConfirmStore cross-process lock (#127) + accurate posture flag (#128)

### DIFF
--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -255,6 +255,15 @@ def build_posture_report(config: "McpServerConfig") -> dict:
     except Exception:
         fernet_available = False
 
+    # #128: the legacy-path rate limiter is only active when the token store's
+    # _RateLimiter is importable AND a positive limit is configured — mirror the
+    # handler's actual condition, don't report the config value alone.
+    try:
+        from soar_mcp_tokens import _RateLimiter  # noqa: F401
+        _rate_limiter_available = True
+    except Exception:
+        _rate_limiter_available = False
+
     enabled_write = sorted(config.enabled_tools - READ_ONLY_TOOLS)
     ssl = config.ssl_verify if isinstance(config.ssl_verify, bool) else "custom_path"
 
@@ -280,7 +289,8 @@ def build_posture_report(config: "McpServerConfig") -> dict:
         "scoped_tokens_enabled": config.scoped_tokens_enabled,
         "scoped_tokens_required": config.scoped_tokens_required,
         "fernet_available": fernet_available,
-        "legacy_path_rate_limited": config.token_rate_limit_per_minute > 0,
+        "legacy_path_rate_limited": bool(
+            _rate_limiter_available and config.token_rate_limit_per_minute > 0),
         "advisory_disclaimer": config.advisory_disclaimer,
         "risk_flags": risk_flags,
     }

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -20,6 +20,7 @@ Copyright 2026 Andreas Buis
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -4374,9 +4375,44 @@ class _ConfirmStore:
         return {k: v for k, v in data.items()
                 if isinstance(v, list) and len(v) == 3 and v[2] > now}
 
+    @contextlib.contextmanager
+    def _file_lock(self):
+        """Exclusive cross-process lock around the read-modify-write (#127).
+
+        A per-process threading.Lock is not enough: SOAR's handler is
+        multi-process, so two workers could interleave load/modify/save and drop
+        a concurrently-issued token. flock serialises the critical section across
+        processes. On non-POSIX systems (no fcntl) this degrades to best-effort.
+        """
+        import os as _os
+        try:
+            import fcntl
+        except Exception:
+            yield
+            return
+        # Acquire (setup errors → proceed best-effort without a lock).
+        fd = None
+        try:
+            _os.makedirs(_os.path.dirname(self._path), exist_ok=True)
+            fd = open(self._path + ".lock", "w", encoding="utf-8")
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        except Exception:
+            if fd is not None:
+                fd.close()
+            fd = None
+        try:
+            yield
+        finally:
+            if fd is not None:
+                try:
+                    fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+                except Exception:
+                    pass
+                fd.close()
+
     def issue(self, tool: str, args: dict, ttl: float = 300.0) -> str:
         token = "confirm_" + secrets.token_urlsafe(9)
-        with self._lock:
+        with self._lock, self._file_lock():
             data = self._prune(self._load())
             data[self._token_hash(token)] = [tool, self._args_hash(tool, args), time.time() + ttl]
             self._save(data)
@@ -4384,7 +4420,7 @@ class _ConfirmStore:
 
     def consume(self, token: str, tool: str, args: dict) -> bool:
         th = self._token_hash(str(token))
-        with self._lock:
+        with self._lock, self._file_lock():
             data = self._load()
             entry = data.get(th)
             data = self._prune(data)          # drop expired (incl. possibly this one)

--- a/test_soar_mcp_confirm_and_harness.py
+++ b/test_soar_mcp_confirm_and_harness.py
@@ -57,6 +57,27 @@ class ConfirmStorePersistenceTest(unittest.TestCase):
             content = fh.read()
         self.assertNotIn(tok, content)  # only the hash is persisted
 
+    def test_two_issuers_do_not_clobber(self):
+        # #127: two store instances (simulating two handler workers) issuing
+        # tokens must both persist — no lost-update from the read-modify-write.
+        t1 = _ConfirmStore(self.path).issue("run_playbook", {"a": 1})
+        t2 = _ConfirmStore(self.path).issue("run_playbook", {"a": 2})
+        self.assertTrue(_ConfirmStore(self.path).consume(t1, "run_playbook", {"a": 1}))
+        self.assertTrue(_ConfirmStore(self.path).consume(t2, "run_playbook", {"a": 2}))
+
+
+class PostureRateLimitTest(unittest.TestCase):
+    """#128: legacy_path_rate_limited reflects the actual limiter condition."""
+
+    def test_reflects_rate_and_limiter_availability(self):
+        from soar_mcp_config import build_posture_report
+        cfg = McpServerConfig()
+        cfg.token_rate_limit_per_minute = 120
+        # _RateLimiter is importable in this env → active when rate > 0.
+        self.assertTrue(build_posture_report(cfg)["legacy_path_rate_limited"])
+        cfg.token_rate_limit_per_minute = 0
+        self.assertFalse(build_posture_report(cfg)["legacy_path_rate_limited"])
+
 
 class _FakeContainerClient:
     def __init__(self, label="events", name="mcp_write_suite_1", delete_err=None,


### PR DESCRIPTION
Two self-audit fixes.

**#127** — `_ConfirmStore` gets an `fcntl.flock` around its read-modify-write so concurrent issues across SOAR's multi-process handler don't drop a token (per-process threading.Lock was insufficient). Best-effort on non-POSIX.

**#128** — `legacy_path_rate_limited` in the posture now reflects the handler's real condition (`_RateLimiter` importable **and** rate > 0), not just the config value.

**Verifikation:** `unittest discover`: **106 tests, OK** (two-issuer no-clobber + posture True/False).

Closes #127, closes #128. 🤖 Generated with [Claude Code](https://claude.com/claude-code)