### PR TITLE
feat(policy): decision core + config + tests (Policy-Layer P1, #136)

### DIFF
--- a/policy/policy_config.json
+++ b/policy/policy_config.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "_comment": "Category -> base gate for the run_playbook policy guard (issue #135/#136). Unknown category -> default_gate (fail-safe). Data-driven: extend categories without code changes. Align against the instance's real list_playbooks categories.",
+  "default_gate": "APPROVE_2PERSON",
+
+  "categories": {
+    "Enrichment": "ALLOW",
+    "Identifier Reputation Analysis": "ALLOW",
+    "Identifier Activity Analysis": "ALLOW",
+    "Attribute Lookup": "ALLOW",
+    "Dynamic Analysis": "ALLOW",
+    "Related Tickets Search": "ALLOW",
+
+    "Message Eviction": "APPROVE_1CLICK",
+    "Message Restoration": "ALLOW",
+    "Search and Purge": "APPROVE_1CLICK",
+    "Search and Restore": "ALLOW",
+
+    "Containment": "APPROVE_2PERSON",
+    "Isolation": "APPROVE_2PERSON",
+    "Process Termination": "APPROVE_2PERSON",
+    "Account Locking": "APPROVE_2PERSON",
+    "Account Unlocking": "APPROVE_1CLICK",
+    "Disable Account": "APPROVE_2PERSON",
+    "Enable Account": "APPROVE_1CLICK",
+    "DNS Denylisting": "APPROVE_2PERSON",
+    "Executable Denylisting": "APPROVE_2PERSON",
+    "File Eviction": "APPROVE_2PERSON",
+    "File Collection": "APPROVE_1CLICK",
+    "File Restore": "ALLOW",
+    "Network Restore": "APPROVE_1CLICK",
+    "Response": "APPROVE_2PERSON"
+  },
+
+  "irreversible_categories": [
+    "Containment", "Isolation", "Process Termination", "Account Locking",
+    "Disable Account", "DNS Denylisting", "Executable Denylisting", "File Eviction"
+  ],
+
+  "risk": {
+    "weights": {
+      "asset_criticality": 0.5,
+      "reversibility": 0.3,
+      "low_confidence": 0.2
+    },
+    "escalate_thresholds": {
+      "to_1click": 0.34,
+      "to_2person": 0.67
+    }
+  },
+
+  "always_2person_targets": {
+    "asset_tags": ["domain_controller", "crown_jewel", "ot", "prod_db"],
+    "identity_tags": ["executive", "admin", "service_account"]
+  }
+}

--- a/policy/policy_layer.py
+++ b/policy/policy_layer.py
@@ -1,0 +1,154 @@
+"""
+SOAR MCP Server — Policy Layer (gated-autonomous run_playbook, issue #135/#136)
+
+A narrow policy guard that decides how a playbook run may proceed:
+  ALLOW           — autonomous (audit only)
+  APPROVE_1CLICK  — reversible, one approver
+  APPROVE_2PERSON — irreversible / high-impact, two approvers
+  DENY            — fail-safe (unknown category, policy error)
+
+Pure decision logic — no SOAR access. The category → base gate mapping lives in
+policy_config.json (data-driven; extend without code changes). The risk score can
+only *escalate* a gate, never relax it, so the default is always safe.
+
+Design decisions (per epic #135): JSON config (no new dependency), fail-safe to
+the configured default (never ALLOW) for anything unknown.
+
+Copyright 2026 Andreas Buis
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional, Union
+
+log = logging.getLogger("soar_mcp.policy")
+
+_DEFAULT_CONFIG = Path(__file__).parent / "policy_config.json"
+
+
+class Gate(IntEnum):
+    """Order = strictness. max() returns the strictest gate."""
+    ALLOW = 0
+    APPROVE_1CLICK = 1
+    APPROVE_2PERSON = 2
+    DENY = 3
+
+    @classmethod
+    def from_name(cls, name: object) -> "Gate":
+        try:
+            return cls[str(name)]
+        except KeyError:
+            log.warning("unknown gate name %r -> DENY (fail-safe)", name)
+            return cls.DENY
+
+
+@dataclass
+class ActionContext:
+    """What the guard knows about the planned run_playbook action."""
+    playbook_id: int
+    playbook_name: str
+    category: str
+    reversible: bool = True
+    agent_confidence: float = 0.5          # 0..1 (missing -> 0.5)
+    asset_criticality: float = 0.0         # 0..1
+    target_asset_tags: list[str] = field(default_factory=list)
+    target_identity_tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PolicyDecision:
+    gate: Gate
+    reason: str
+    risk_score: float
+    context: ActionContext
+
+    @property
+    def needed_approvers(self) -> int:
+        return {Gate.APPROVE_1CLICK: 1, Gate.APPROVE_2PERSON: 2}.get(self.gate, 0)
+
+    def to_dict(self) -> dict:
+        return {
+            "gate": self.gate.name,
+            "reason": self.reason,
+            "risk_score": round(self.risk_score, 3),
+            "needed_approvers": self.needed_approvers,
+            "playbook_id": self.context.playbook_id,
+            "playbook_name": self.context.playbook_name,
+            "category": self.context.category,
+        }
+
+
+class PolicyLayer:
+    def __init__(self, config_path: Union[str, Path, None] = None):
+        self._cfg = self._load(config_path or _DEFAULT_CONFIG)
+        self._default = Gate.from_name(self._cfg.get("default_gate", "DENY"))
+        self._categories = self._cfg.get("categories", {}) or {}
+        self._irreversible = {
+            str(c).lower() for c in (self._cfg.get("irreversible_categories") or [])
+        }
+        self._risk = self._cfg.get("risk", {}) or {}
+        self._targets = self._cfg.get("always_2person_targets", {}) or {}
+
+    @staticmethod
+    def _load(path: Union[str, Path]) -> dict:
+        try:
+            data = json.loads(Path(path).read_text(encoding="utf-8"))
+            return data if isinstance(data, dict) else {}
+        except Exception as exc:
+            # Fail-safe: no config -> empty dict -> default_gate falls back to DENY.
+            log.error("[policy] could not load config %s: %s -> DENY defaults", path, exc)
+            return {}
+
+    def category_is_reversible(self, category: str) -> bool:
+        """Ground truth for reversibility from config (irreversible list)."""
+        return str(category).lower() not in self._irreversible
+
+    def evaluate(self, ctx: ActionContext) -> PolicyDecision:
+        # 1) Base gate from category (unknown -> fail-safe default, never ALLOW).
+        base_name = self._categories.get(ctx.category)
+        if base_name is None:
+            log.warning("[policy] category %r not in policy -> default %s",
+                        ctx.category, self._default.name)
+            base = self._default
+        else:
+            base = Gate.from_name(base_name)
+
+        # 2) Risk score -> possible escalation (never relaxation).
+        w = self._risk.get("weights", {})
+        score = (
+            float(w.get("asset_criticality", 0.0)) * _clamp01(ctx.asset_criticality)
+            + float(w.get("reversibility", 0.0)) * (0.0 if ctx.reversible else 1.0)
+            + float(w.get("low_confidence", 0.0)) * (1.0 - _clamp01(ctx.agent_confidence))
+        )
+        th = self._risk.get("escalate_thresholds", {})
+        risk_gate = Gate.ALLOW
+        if score >= float(th.get("to_2person", 1.1)):
+            risk_gate = Gate.APPROVE_2PERSON
+        elif score >= float(th.get("to_1click", 1.1)):
+            risk_gate = Gate.APPROVE_1CLICK
+
+        # 3) Target override: critical assets/identities -> always 2-person.
+        override = Gate.ALLOW
+        if _overlap(ctx.target_asset_tags, self._targets.get("asset_tags", [])) or \
+                _overlap(ctx.target_identity_tags, self._targets.get("identity_tags", [])):
+            override = Gate.APPROVE_2PERSON
+
+        gate = max(base, risk_gate, override)
+        reason = (f"base={base.name} risk={score:.2f}->{risk_gate.name} "
+                  f"override={override.name} => {gate.name}")
+        return PolicyDecision(gate=gate, reason=reason, risk_score=score, context=ctx)
+
+
+def _clamp01(x: object) -> float:
+    try:
+        return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _overlap(a: list, b: list) -> bool:
+    return bool({str(x).lower() for x in (a or [])} & {str(x).lower() for x in (b or [])})

--- a/test_policy_layer.py
+++ b/test_policy_layer.py
@@ -1,0 +1,81 @@
+"""Tests for the Policy Layer decision logic (issue #136). Pure logic, no SOAR."""
+from __future__ import annotations
+
+import unittest
+
+from policy.policy_layer import ActionContext, Gate, PolicyLayer
+
+
+class PolicyLayerTest(unittest.TestCase):
+    def setUp(self):
+        self.policy = PolicyLayer()  # loads policy/policy_config.json
+
+    # --- Spec §7 acceptance cases -------------------------------------------
+
+    def test_enrichment_is_autonomous(self):
+        d = self.policy.evaluate(ActionContext(1, "VT_Enrich", "Enrichment", agent_confidence=0.9))
+        self.assertIs(d.gate, Gate.ALLOW)
+
+    def test_host_isolation_needs_two(self):
+        d = self.policy.evaluate(ActionContext(25, "CS_Isolation", "Containment", reversible=False))
+        self.assertIs(d.gate, Gate.APPROVE_2PERSON)
+
+    def test_unknown_category_fails_safe(self):
+        d = self.policy.evaluate(ActionContext(999, "X", "TotallyNewCategory"))
+        self.assertIs(d.gate, Gate.APPROVE_2PERSON)   # = default_gate, never ALLOW
+        self.assertNotEqual(d.gate, Gate.ALLOW)
+
+    def test_low_confidence_escalates_enrichment(self):
+        d = self.policy.evaluate(ActionContext(1, "E", "Enrichment",
+                                               agent_confidence=0.0, asset_criticality=1.0))
+        self.assertGreaterEqual(d.gate, Gate.APPROVE_1CLICK)
+
+    def test_exec_target_forces_two(self):
+        d = self.policy.evaluate(ActionContext(6, "AD_Enable", "Enable Account",
+                                               target_identity_tags=["executive"]))
+        self.assertIs(d.gate, Gate.APPROVE_2PERSON)   # override beats mild category
+
+    # --- Additional guardrails ----------------------------------------------
+
+    def test_risk_only_escalates_never_relaxes(self):
+        # A 2-person category stays 2-person even with perfect confidence / low crit.
+        d = self.policy.evaluate(ActionContext(2, "Block", "Containment",
+                                               reversible=False, agent_confidence=1.0,
+                                               asset_criticality=0.0))
+        self.assertIs(d.gate, Gate.APPROVE_2PERSON)
+
+    def test_message_eviction_is_one_click(self):
+        d = self.policy.evaluate(ActionContext(3, "Evict", "Message Eviction"))
+        self.assertIs(d.gate, Gate.APPROVE_1CLICK)
+
+    def test_message_restoration_is_allow(self):
+        d = self.policy.evaluate(ActionContext(4, "Restore", "Message Restoration"))
+        self.assertIs(d.gate, Gate.ALLOW)
+
+    def test_needed_approvers(self):
+        self.assertEqual(self.policy.evaluate(
+            ActionContext(1, "E", "Enrichment")).needed_approvers, 0)
+        self.assertEqual(self.policy.evaluate(
+            ActionContext(3, "Evict", "Message Eviction")).needed_approvers, 1)
+        self.assertEqual(self.policy.evaluate(
+            ActionContext(25, "Iso", "Containment")).needed_approvers, 2)
+
+    def test_category_reversibility_from_config(self):
+        self.assertFalse(self.policy.category_is_reversible("Containment"))
+        self.assertTrue(self.policy.category_is_reversible("Enrichment"))
+
+    def test_missing_config_fails_safe_to_deny(self):
+        p = PolicyLayer("/nonexistent/policy_config.json")
+        d = p.evaluate(ActionContext(1, "E", "Enrichment"))
+        self.assertIs(d.gate, Gate.DENY)   # no config -> default DENY, never ALLOW
+
+    def test_decision_to_dict_has_no_surprises(self):
+        d = self.policy.evaluate(ActionContext(1, "VT", "Enrichment"))
+        j = d.to_dict()
+        self.assertEqual(j["gate"], "ALLOW")
+        self.assertIn("risk_score", j)
+        self.assertEqual(j["needed_approvers"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Neu:** `policy/policy_layer.py`, `policy/policy_config.json`, `policy/__init__.py`, `test_policy_layer.py`
- **Edit:** keine (Core ist isoliert — noch **nicht** in den Dispatch-Pfad verdrahtet; das ist P2/#137)
- **Unangetastet:** gesamter Server

## Issue #136 (Phase 1/4 von #135)
Reine Decision-Logik, kein SOAR-Zugriff. Entscheidungen D1–D4 wie in #135 empfohlen: **JSON-Config** (keine neue Dependency), fail-safe.

- `Gate` (ALLOW<1CLICK<2PERSON<DENY, max()=strengste)
- `PolicyLayer.evaluate`: Category→base (unbekannt ⇒ default_gate, **nie ALLOW**), Risk **eskaliert nur**, Ziel-Override (crit asset/identity ⇒ 2PERSON)
- Config data-driven (`policy_config.json`), Kategorien der Spec §4

## Verifikation (L6, Volloutput)
- `unittest test_policy_layer`: **12/12 OK** — inkl. unbekannte Category→2PERSON, fehlende Config→DENY, Risk-nur-verschärft, Override, needed_approvers
- Volle Suite grün

Teil 1/4 von #135. 🤖 Generated with [Claude Code](https://claude.com/claude-code)