### PR TITLE
feat(policy): guard integration in call_tool (P2, #137)

### DIFF
--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -299,3 +299,17 @@ default_lifetime_days = 90
 # rate_limit_per_minute * <worker_count>. Do not rely on this as a hard
 # DoS ceiling — use a reverse-proxy rate limit for that.
 rate_limit_per_minute = 120
+
+# ==============================================================================
+# [policy] — Gated-autonomous run_playbook (issue #135). Opt-in.
+# ==============================================================================
+
+[policy]
+# When true, every run_playbook is evaluated by the policy guard before dispatch:
+#   ALLOW           -> autonomous (audit only)
+#   APPROVE_1CLICK  -> reversible, held for one approver
+#   APPROVE_2PERSON -> irreversible/high-impact, held for two approvers
+#   DENY            -> blocked (fail-safe: unknown category, policy error)
+# The category -> base-gate mapping lives in policy/policy_config.json (data-driven).
+# Default: false (backwards-compatible).
+enabled = false

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -194,6 +194,10 @@ class McpServerConfig:
     # also treats a name starting with test_container_name_prefix as suite-owned.
     test_container_label: str = "test"
     test_container_name_prefix: str = "mcp_"
+    # Policy layer (gated-autonomous run_playbook, issue #135). Opt-in. When true,
+    # every run_playbook is evaluated by the policy guard (ALLOW / APPROVE_1CLICK /
+    # APPROVE_2PERSON / DENY) before dispatch. Default off = backwards-compatible.
+    policy_enabled: bool = False
 
     # AI instructions — sent to the LLM in every MCP initialize response
     ai_instructions: str = ""
@@ -377,6 +381,7 @@ class McpConfigLoader:
         config.min_severity = raw_sev if raw_sev in _VALID_SEVERITIES else ""
         config.enable_test_harness = self._get_bool(parser, "safety", "enable_test_harness", False)
         config.require_confirmation = self._get_bool(parser, "safety", "require_confirmation", False)
+        config.policy_enabled = self._get_bool(parser, "policy", "enabled", False)
         config.test_container_label = (
             parser.get("safety", "test_container_label", fallback="test").strip() or "test")
         config.test_container_name_prefix = (

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -4483,6 +4483,71 @@ def _maybe_require_confirmation(
     )
 
 
+# ── Policy layer gate for run_playbook (gated autonomy, issue #135/#137) ──────
+_policy_layer = None
+
+
+def _get_policy_layer():
+    global _policy_layer
+    if _policy_layer is None:
+        from policy.policy_layer import PolicyLayer
+        _policy_layer = PolicyLayer()
+    return _policy_layer
+
+
+def _policy_gate(
+    tool_name: str, arguments: dict, client: SoarApiClient, config: McpServerConfig
+) -> Optional[str]:
+    """Gated-autonomous run_playbook (#137). Returns a block/hold message, or None
+    to proceed. Only acts on run_playbook when [policy] enabled = true. Every
+    decision is audited (including ALLOW). Fail-safe: any error -> not ALLOW."""
+    if tool_name != "run_playbook" or not getattr(config, "policy_enabled", False):
+        return None
+
+    from policy.policy_layer import ActionContext, Gate
+
+    pid, err = _require_positive_int(arguments.get("playbook_id"), "playbook_id")
+    if err:
+        return None  # let tool_run_playbook report the invalid id itself
+
+    try:
+        policy = _get_policy_layer()
+    except Exception as exc:
+        logger.error("[soar_mcp.policy] layer unavailable: %s -> DENY (fail-safe)", exc)
+        return f"⛔ Blocked by policy: policy layer unavailable ({type(exc).__name__})."
+
+    # Load the playbook category (fail-safe: unknown -> default_gate, never ALLOW).
+    category, name = "", ""
+    pb, _pb_err = client.get(f"playbook/{pid}")
+    if isinstance(pb, dict):
+        category = pb.get("category") or ""
+        name = pb.get("name") or ""
+
+    ctx = ActionContext(
+        playbook_id=pid,
+        playbook_name=name,
+        category=category,
+        reversible=policy.category_is_reversible(category),
+        agent_confidence=arguments.get("agent_confidence", 0.5),
+    )
+    decision = policy.evaluate(ctx)
+    logger.info("[soar_mcp.policy] decision=%s",
+                json.dumps(decision.to_dict(), default=str))
+
+    if decision.gate == Gate.ALLOW:
+        return None
+    if decision.gate == Gate.DENY:
+        return f"⛔ Blocked by policy (DENY): {decision.reason}"
+    # 1CLICK / 2PERSON: hold. The approval collection is P3 (#138); until then the
+    # run is held rather than executed — never silently allowed.
+    return (
+        f"⏸ Approval required by policy — {decision.needed_approvers} approver(s).\n"
+        f"  Playbook: {name or pid} | Category: {category or 'unknown'}\n"
+        f"  Gate: {decision.gate.name} — {decision.reason}\n"
+        "Execution is held pending human approval (approval workflow: issue #138)."
+    )
+
+
 def call_tool(
     tool_name: str,
     arguments: dict,
@@ -4498,6 +4563,10 @@ def call_tool(
     handler = _TOOL_HANDLERS.get(tool_name)
     if handler is None:
         return f"Unknown tool: '{tool_name}'"
+    # Policy gate first (gated autonomy) — may block/hold run_playbook (#137).
+    policy_msg = _policy_gate(tool_name, arguments or {}, client, config)
+    if policy_msg is not None:
+        return policy_msg
     gate = _maybe_require_confirmation(tool_name, arguments or {}, config)
     if gate is not None:
         return gate

--- a/test_policy_gate.py
+++ b/test_policy_gate.py
@@ -1,0 +1,78 @@
+"""Tests for the policy gate wired into call_tool (issue #137)."""
+from __future__ import annotations
+
+import unittest
+
+from soar_mcp_config import McpServerConfig
+from soar_mcp_tools import call_tool
+
+
+class _FakeClient:
+    """Returns a playbook with a given category; records whether run happened."""
+    def __init__(self, category="Enrichment"):
+        self._base_url = "https://s/rest"
+        self._category = category
+        self.ran = False
+
+    def get(self, path, params=None):
+        if path.startswith("playbook/"):
+            return {"id": 1, "name": "PB", "category": self._category}, None
+        return {}, None
+
+    def post(self, path, body):
+        if path == "playbook_run":
+            self.ran = True
+            return {"playbook_run_id": 99}, None
+        return {}, None
+
+
+def _cfg(policy=False):
+    c = McpServerConfig()
+    c.policy_enabled = policy
+    c.advisory_disclaimer = False
+    return c
+
+
+class PolicyGateTest(unittest.TestCase):
+    def test_policy_disabled_runs_normally(self):
+        c = _FakeClient("Containment")  # would be 2-person, but policy is off
+        call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=False))
+        self.assertTrue(c.ran)
+
+    def test_allow_category_runs(self):
+        c = _FakeClient("Enrichment")
+        call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
+        self.assertTrue(c.ran)
+
+    def test_two_person_category_is_held(self):
+        c = _FakeClient("Containment")
+        out = call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
+        self.assertFalse(c.ran)
+        self.assertIn("Approval required", out)
+        self.assertIn("2 approver", out)
+
+    def test_one_click_category_is_held(self):
+        c = _FakeClient("Message Eviction")
+        out = call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
+        self.assertFalse(c.ran)
+        self.assertIn("1 approver", out)
+
+    def test_unknown_category_held_never_runs(self):
+        # fail-safe: unknown category -> default_gate (2-person) -> held
+        c = _FakeClient("ZzzTotallyUnknownCategory")
+        out = call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
+        self.assertFalse(c.ran)
+        self.assertIn("Approval required", out)
+
+    def test_other_write_tool_not_policy_gated(self):
+        # policy only guards run_playbook (D2). A different tool is untouched by it.
+        c = _FakeClient("Enrichment")
+        cfg = _cfg(policy=True)
+        cfg.enabled_tools = {"get_soar_info"}
+        # get_soar_info would call client.get('version'); our fake returns {} -> ok-ish.
+        out = call_tool("get_soar_info", {}, c, cfg)
+        self.assertNotIn("Approval required", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Edit:** `soar_mcp_tools.py` (`call_tool` + `_policy_gate`), `soar_mcp_config.py` (`policy_enabled`), `default/mcp.conf` (`[policy] enabled`)
- **Neu:** `test_policy_gate.py`
- **Unangetastet:** Playbook-Ausführung selbst, alle anderen Tools, externe Signaturen

## Issue #137 (Phase 2/4 von #135)
Policy-Guard im **Chokepoint** `call_tool`, **nur** `run_playbook`, **default-off** (opt-in). Category wird nachgeladen; ALLOW→dispatch, DENY→block, 1CLICK/2PERSON→**HOLD** (nicht ausgeführt, bis P3/#138 die Approvals einsammelt). Jede Entscheidung auditiert.

Fail-safe: Category unbekannt/Fetch-Fehler ⇒ default_gate (nie ALLOW). Guard unumgehbar (im Server).

## Verifikation
- `unittest discover`: **125 Tests, OK** — 6 neue Gate-Tests (allow läuft; 2-person/1-click/unknown gehalten; disabled läuft; andere Tools ungated)

Teil 2/4 von #135. 🤖 Generated with [Claude Code](https://claude.com/claude-code)