### PR TITLE
feat(policy): distinct-approver approval workflow (P3, #138)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ __pycache__/
 *.pyc
 *.pyo
 .DS_Store
+
+# Per-instance runtime state (created on the SOAR host, never committed):
+# scoped tokens, pending confirmations (#116), pending approvals (#138), base_url.
+local/

--- a/policy/approvals.py
+++ b/policy/approvals.py
@@ -1,0 +1,176 @@
+"""Approval store for the policy layer (issue #138, Phase 3).
+
+Collects one (APPROVE_1CLICK) or two *distinct* (APPROVE_2PERSON) human
+approvals for a held run_playbook before it may execute. Modeled on the #50
+_ConfirmStore: file-backed so it survives SOAR's multi-process REST handler,
+fcntl-locked around the read-modify-write, TTL-bound, single-use on completion.
+
+Identity is the scoped-token soar_user_id (D3). Two-person separation is
+enforced here: the same approver id cannot count twice, so two *different*
+humans (two different scoped tokens) are required — no self-approval.
+
+Fail-safe: a missing/expired/mismatched token yields INVALID; nothing executes
+without the full set of distinct approvers. Only a SHA-256 hash of the token is
+ever stored, never the raw token.
+
+An entry is a 5-list: [tool, args_hash, expiry, needed, [approver_ids...]].
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+_TTL_DEFAULT = 600.0  # 10 min — two humans need longer to coordinate than a confirm
+
+
+@dataclass(frozen=True)
+class ApprovalResult:
+    """Outcome of submit(). status is one of: approved | pending | duplicate | invalid."""
+    status: str
+    have: int = 0
+    need: int = 0
+
+    @property
+    def approved(self) -> bool:
+        return self.status == "approved"
+
+
+class ApprovalStore:
+    """File-backed, TTL-bound, distinct-approver approval tokens keyed on (tool, args)."""
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        app_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        self._path = path or os.path.join(app_dir, "local", "pending_approvals.json")
+        self._lock = threading.Lock()
+
+    # --- hashing (raw token / args never stored in the clear) ----------------
+
+    @staticmethod
+    def _args_hash(tool: str, args: dict) -> str:
+        blob = tool + "|" + json.dumps(args, sort_keys=True, default=str)
+        return hashlib.sha256(blob.encode()).hexdigest()
+
+    @staticmethod
+    def _token_hash(token: str) -> str:
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    # --- persistence ---------------------------------------------------------
+
+    def _load(self) -> dict:
+        try:
+            if os.path.exists(self._path):
+                with open(self._path, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                    return data if isinstance(data, dict) else {}
+        except Exception:
+            pass
+        return {}
+
+    def _save(self, data: dict) -> None:
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+            tmp = self._path + ".tmp"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            os.replace(tmp, self._path)
+            try:
+                os.chmod(self._path, 0o600)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+    @staticmethod
+    def _prune(data: dict) -> dict:
+        now = time.time()
+        return {k: v for k, v in data.items()
+                if isinstance(v, list) and len(v) == 5 and v[2] > now}
+
+    @contextlib.contextmanager
+    def _file_lock(self):
+        """Exclusive cross-process lock around read-modify-write (mirrors #127)."""
+        try:
+            import fcntl
+        except Exception:
+            yield
+            return
+        fd = None
+        try:
+            os.makedirs(os.path.dirname(self._path), exist_ok=True)
+            fd = open(self._path + ".lock", "w", encoding="utf-8")
+            fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+        except Exception:
+            if fd is not None:
+                fd.close()
+            fd = None
+        try:
+            yield
+        finally:
+            if fd is not None:
+                try:
+                    fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+                except Exception:
+                    pass
+                fd.close()
+
+    # --- API -----------------------------------------------------------------
+
+    def issue(self, tool: str, args: dict, needed: int, ttl: float = _TTL_DEFAULT) -> str:
+        """Open an approval request; return the token the approver(s) must present."""
+        needed = max(1, int(needed))
+        token = "approve_" + secrets.token_urlsafe(9)
+        with self._lock, self._file_lock():
+            data = self._prune(self._load())
+            data[self._token_hash(token)] = [
+                tool, self._args_hash(tool, args), time.time() + ttl, needed, []
+            ]
+            self._save(data)
+        return token
+
+    def submit(self, token: str, tool: str, args: dict, approver_id: str) -> ApprovalResult:
+        """Record one approval from approver_id. Returns the resulting state.
+
+        - approved : the needed number of *distinct* approvers is met (token consumed)
+        - pending  : recorded, more distinct approver(s) still required
+        - duplicate: approver_id already approved this token (not counted again)
+        - invalid  : no/expired/mismatched token, or empty approver_id
+        """
+        approver = (approver_id or "").strip()
+        if not approver:
+            return ApprovalResult("invalid")
+        th = self._token_hash(str(token))
+        now = time.time()
+        with self._lock, self._file_lock():
+            data = self._load()
+            entry = data.get(th)
+            if entry is None or not isinstance(entry, list) or len(entry) != 5 or entry[2] <= now:
+                if entry is not None:
+                    data.pop(th, None)     # expired/garbage cleanup
+                    self._save(data)
+                return ApprovalResult("invalid")
+            # Wrong tool/args must NOT nuke a legitimate pending approval.
+            if entry[0] != tool or entry[1] != self._args_hash(tool, args):
+                return ApprovalResult("invalid")
+
+            needed = int(entry[3])
+            approvers = list(entry[4]) if isinstance(entry[4], list) else []
+            if approver in approvers:
+                return ApprovalResult("duplicate", have=len(approvers), need=needed)
+
+            approvers.append(approver)
+            if len(approvers) >= needed:
+                data.pop(th, None)         # single-use: consume on completion
+                self._save(data)
+                return ApprovalResult("approved", have=len(approvers), need=needed)
+
+            entry[4] = approvers
+            data[th] = entry
+            self._save(data)
+            return ApprovalResult("pending", have=len(approvers), need=needed)

--- a/soar_mcp_handler.py
+++ b/soar_mcp_handler.py
@@ -365,7 +365,10 @@ class SoarMcpRestHandler(dict):
             return {"content": [{"type": "text", "text": text}], "isError": True}
 
         self._audit_tool_call(token_verification, tool_name, arguments, outcome="ok")
-        result_text = call_tool(tool_name, arguments, client, config)
+        # Scoped-token identity is the accountable approver for the policy layer
+        # (#138); legacy full tokens have no bound user -> None (fail-safe HOLD).
+        actor_id = token_verification.soar_user_id if token_verification is not None else None
+        result_text = call_tool(tool_name, arguments, client, config, actor_id=actor_id)
         is_error = self._is_tool_error(result_text)
         return {"content": [{"type": "text", "text": result_text}], "isError": is_error}
 

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -4495,12 +4495,26 @@ def _get_policy_layer():
     return _policy_layer
 
 
+_approval_store = None
+
+
+def _get_approval_store():
+    global _approval_store
+    if _approval_store is None:
+        from policy.approvals import ApprovalStore
+        _approval_store = ApprovalStore()
+    return _approval_store
+
+
 def _policy_gate(
-    tool_name: str, arguments: dict, client: SoarApiClient, config: McpServerConfig
+    tool_name: str, arguments: dict, client: SoarApiClient, config: McpServerConfig,
+    actor_id: Optional[str] = None,
 ) -> Optional[str]:
-    """Gated-autonomous run_playbook (#137). Returns a block/hold message, or None
-    to proceed. Only acts on run_playbook when [policy] enabled = true. Every
-    decision is audited (including ALLOW). Fail-safe: any error -> not ALLOW."""
+    """Gated-autonomous run_playbook (#137/#138). Returns a block/hold/approval
+    message, or None to proceed. Only acts on run_playbook when [policy]
+    enabled = true. Every decision is audited (including ALLOW). Fail-safe: any
+    error -> not ALLOW. 1CLICK/2PERSON collect distinct human approval(s) keyed
+    on the scoped-token identity (actor_id) before execution."""
     if tool_name != "run_playbook" or not getattr(config, "policy_enabled", False):
         return None
 
@@ -4538,14 +4552,50 @@ def _policy_gate(
         return None
     if decision.gate == Gate.DENY:
         return f"⛔ Blocked by policy (DENY): {decision.reason}"
-    # 1CLICK / 2PERSON: hold. The approval collection is P3 (#138); until then the
-    # run is held rather than executed — never silently allowed.
-    return (
-        f"⏸ Approval required by policy — {decision.needed_approvers} approver(s).\n"
-        f"  Playbook: {name or pid} | Category: {category or 'unknown'}\n"
-        f"  Gate: {decision.gate.name} — {decision.reason}\n"
-        "Execution is held pending human approval (approval workflow: issue #138)."
-    )
+
+    # 1CLICK / 2PERSON: collect distinct human approval(s) before executing (#138).
+    needed = decision.needed_approvers
+    key_args = {k: v for k, v in arguments.items() if k != "approval_token"}
+    provided = arguments.get("approval_token")
+    head = (f"  Playbook: {name or pid} | Category: {category or 'unknown'} | "
+            f"Gate: {decision.gate.name}\n")
+
+    # The approver identity is the scoped-token soar_user_id. Without a scoped
+    # token there is no accountable approver -> fail-safe HOLD (never executes).
+    if not actor_id:
+        return (
+            f"⏸ Approval required by policy — {needed} distinct approver(s).\n" + head +
+            "  This SOAR MCP token is not a scoped token, so no accountable approver "
+            "identity is available. Mint a scoped MCP token per approver ('mint mcp "
+            "token' action) and retry; execution stays held until then."
+        )
+
+    store = _get_approval_store()
+    if not provided:
+        token = store.issue("run_playbook", key_args, needed)
+        two = "Two DIFFERENT SOAR users must each approve (no self-approval).\n" if needed >= 2 else ""
+        return (
+            f"⏸ Approval required by policy — {needed} distinct approver(s) needed.\n" + head +
+            f"  Reason: {decision.reason}\n\n"
+            "Each approver calls run_playbook again with the SAME arguments plus:\n"
+            f'  approval_token = "{token}"\n' + two +
+            "The token is valid for 10 minutes and only for these exact arguments."
+        )
+
+    res = store.submit(str(provided), "run_playbook", key_args, actor_id)
+    logger.info("[soar_mcp.policy] approval status=%s have=%d need=%d approver=%s pid=%s",
+                res.status, res.have, res.need, actor_id, pid)
+    if res.approved:
+        return None  # fully approved -> fall through to dispatch
+    if res.status == "duplicate":
+        return (f"⏸ You ({actor_id}) already approved this action ({res.have}/{res.need}). "
+                "A DIFFERENT SOAR user must provide the remaining approval.")
+    if res.status == "pending":
+        return (f"⏸ Approval recorded ({res.have}/{res.need}) by {actor_id}. "
+                f"{res.need - res.have} more distinct approver(s) required — call again with "
+                "the same approval_token as a different SOAR user.")
+    return ("⛔ Invalid or expired approval_token (or the arguments changed). Restart the "
+            "approval: call run_playbook without approval_token to obtain a fresh one.")
 
 
 def call_tool(
@@ -4553,9 +4603,13 @@ def call_tool(
     arguments: dict,
     client: SoarApiClient,
     config: McpServerConfig,
+    actor_id: Optional[str] = None,
 ) -> str:
     """
     Dispatch a tool call to its implementation.
+
+    actor_id is the scoped-token soar_user_id of the caller (None for legacy
+    full tokens); the policy layer uses it as the accountable approver identity.
 
     Returns a text string as the MCP content response.
     Never raises; errors are returned as text.
@@ -4563,8 +4617,9 @@ def call_tool(
     handler = _TOOL_HANDLERS.get(tool_name)
     if handler is None:
         return f"Unknown tool: '{tool_name}'"
-    # Policy gate first (gated autonomy) — may block/hold run_playbook (#137).
-    policy_msg = _policy_gate(tool_name, arguments or {}, client, config)
+    # Policy gate first (gated autonomy) — may block/hold/require approval for
+    # run_playbook (#137/#138).
+    policy_msg = _policy_gate(tool_name, arguments or {}, client, config, actor_id)
     if policy_msg is not None:
         return policy_msg
     gate = _maybe_require_confirmation(tool_name, arguments or {}, config)

--- a/test_policy_approvals.py
+++ b/test_policy_approvals.py
@@ -1,0 +1,86 @@
+"""Unit tests for the policy approval store (issue #138, Phase 3). No SOAR."""
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from policy.approvals import ApprovalStore
+
+
+class ApprovalStoreTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+        self.path = os.path.join(self._dir, "pending_approvals.json")
+        self.store = ApprovalStore(self.path)
+        self.tool = "run_playbook"
+        self.args = {"case_id": 1, "playbook_id": 25}
+
+    # --- 1-click (single approver) ------------------------------------------
+
+    def test_one_click_single_approver_approves(self):
+        tok = self.store.issue(self.tool, self.args, needed=1)
+        res = self.store.submit(tok, self.tool, self.args, "alice")
+        self.assertTrue(res.approved)
+        self.assertEqual((res.have, res.need), (1, 1))
+
+    def test_one_click_token_is_single_use(self):
+        tok = self.store.issue(self.tool, self.args, needed=1)
+        self.assertTrue(self.store.submit(tok, self.tool, self.args, "alice").approved)
+        # second use of a consumed token is invalid
+        self.assertEqual(self.store.submit(tok, self.tool, self.args, "bob").status, "invalid")
+
+    # --- 2-person (two DISTINCT approvers) ----------------------------------
+
+    def test_two_person_needs_two_distinct(self):
+        tok = self.store.issue(self.tool, self.args, needed=2)
+        first = self.store.submit(tok, self.tool, self.args, "alice")
+        self.assertEqual(first.status, "pending")
+        self.assertEqual((first.have, first.need), (1, 2))
+        second = self.store.submit(tok, self.tool, self.args, "bob")
+        self.assertTrue(second.approved)
+        self.assertEqual((second.have, second.need), (2, 2))
+
+    def test_two_person_rejects_self_approval(self):
+        tok = self.store.issue(self.tool, self.args, needed=2)
+        self.assertEqual(self.store.submit(tok, self.tool, self.args, "alice").status, "pending")
+        # same human again -> not counted, still one short
+        dup = self.store.submit(tok, self.tool, self.args, "alice")
+        self.assertEqual(dup.status, "duplicate")
+        self.assertEqual((dup.have, dup.need), (1, 2))
+        # a genuinely different second human completes it
+        self.assertTrue(self.store.submit(tok, self.tool, self.args, "carol").approved)
+
+    def test_empty_approver_is_invalid(self):
+        tok = self.store.issue(self.tool, self.args, needed=1)
+        self.assertEqual(self.store.submit(tok, self.tool, self.args, "").status, "invalid")
+        self.assertEqual(self.store.submit(tok, self.tool, self.args, "   ").status, "invalid")
+
+    # --- token binding / fail-safe ------------------------------------------
+
+    def test_wrong_args_are_invalid_but_do_not_destroy_pending(self):
+        tok = self.store.issue(self.tool, self.args, needed=2)
+        self.store.submit(tok, self.tool, self.args, "alice")            # 1/2 recorded
+        bad = self.store.submit(tok, self.tool, {"case_id": 9, "playbook_id": 9}, "bob")
+        self.assertEqual(bad.status, "invalid")
+        # the legitimate pending approval survived the bad-args call
+        self.assertTrue(self.store.submit(tok, self.tool, self.args, "bob").approved)
+
+    def test_unknown_token_is_invalid(self):
+        self.assertEqual(
+            self.store.submit("approve_nope", self.tool, self.args, "alice").status, "invalid")
+
+    def test_expired_token_is_invalid(self):
+        tok = self.store.issue(self.tool, self.args, needed=1, ttl=-1.0)
+        self.assertEqual(self.store.submit(tok, self.tool, self.args, "alice").status, "invalid")
+
+    def test_survives_new_store_instance(self):
+        # file-backed: a second process (new instance, same path) sees the pending token
+        tok = self.store.issue(self.tool, self.args, needed=2)
+        self.store.submit(tok, self.tool, self.args, "alice")
+        other = ApprovalStore(self.path)
+        self.assertTrue(other.submit(tok, self.tool, self.args, "bob").approved)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_policy_gate.py
+++ b/test_policy_gate.py
@@ -1,10 +1,17 @@
-"""Tests for the policy gate wired into call_tool (issue #137)."""
+"""Tests for the policy gate wired into call_tool (issues #137, #138)."""
 from __future__ import annotations
 
+import os
+import re
+import tempfile
 import unittest
 
+import soar_mcp_tools
+from policy.approvals import ApprovalStore
 from soar_mcp_config import McpServerConfig
 from soar_mcp_tools import call_tool
+
+_TOKEN_RE = re.compile(r'approval_token\s*=\s*"([^"]+)"')
 
 
 class _FakeClient:
@@ -44,18 +51,20 @@ class PolicyGateTest(unittest.TestCase):
         call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
         self.assertTrue(c.ran)
 
-    def test_two_person_category_is_held(self):
+    def test_two_person_no_scoped_identity_is_held(self):
+        # actor_id None (legacy token) -> no accountable approver -> fail-safe HOLD
         c = _FakeClient("Containment")
         out = call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
         self.assertFalse(c.ran)
         self.assertIn("Approval required", out)
-        self.assertIn("2 approver", out)
+        self.assertIn("2 distinct approver", out)
+        self.assertIn("not a scoped token", out)
 
-    def test_one_click_category_is_held(self):
+    def test_one_click_no_scoped_identity_is_held(self):
         c = _FakeClient("Message Eviction")
         out = call_tool("run_playbook", {"case_id": 1, "playbook_id": 1}, c, _cfg(policy=True))
         self.assertFalse(c.ran)
-        self.assertIn("1 approver", out)
+        self.assertIn("1 distinct approver", out)
 
     def test_unknown_category_held_never_runs(self):
         # fail-safe: unknown category -> default_gate (2-person) -> held
@@ -72,6 +81,60 @@ class PolicyGateTest(unittest.TestCase):
         # get_soar_info would call client.get('version'); our fake returns {} -> ok-ish.
         out = call_tool("get_soar_info", {}, c, cfg)
         self.assertNotIn("Approval required", out)
+
+
+class PolicyApprovalFlowTest(unittest.TestCase):
+    """End-to-end approval flow through call_tool with scoped-token identities (#138)."""
+
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+        # isolate the module-level approval store to a temp file
+        self._saved = soar_mcp_tools._approval_store
+        soar_mcp_tools._approval_store = ApprovalStore(
+            os.path.join(self._dir, "pending_approvals.json"))
+        self.args = {"case_id": 1, "playbook_id": 1}
+
+    def tearDown(self):
+        soar_mcp_tools._approval_store = self._saved
+
+    def _issue_token(self, client, actor):
+        out = call_tool("run_playbook", dict(self.args), client, _cfg(policy=True), actor_id=actor)
+        m = _TOKEN_RE.search(out)
+        self.assertIsNotNone(m, f"no approval_token in: {out!r}")
+        return m.group(1)
+
+    def test_two_person_two_distinct_approvers_execute(self):
+        c = _FakeClient("Containment")
+        tok = self._issue_token(c, "alice")
+        a = dict(self.args, approval_token=tok)
+        out1 = call_tool("run_playbook", a, c, _cfg(policy=True), actor_id="alice")
+        self.assertIn("1/2", out1)
+        self.assertFalse(c.ran)
+        out2 = call_tool("run_playbook", a, c, _cfg(policy=True), actor_id="bob")
+        self.assertTrue(c.ran)  # two distinct approvers -> executes
+
+    def test_two_person_self_approval_blocked(self):
+        c = _FakeClient("Containment")
+        tok = self._issue_token(c, "alice")
+        a = dict(self.args, approval_token=tok)
+        call_tool("run_playbook", a, c, _cfg(policy=True), actor_id="alice")
+        out = call_tool("run_playbook", a, c, _cfg(policy=True), actor_id="alice")
+        self.assertIn("already approved", out)
+        self.assertFalse(c.ran)
+
+    def test_one_click_single_approver_executes(self):
+        c = _FakeClient("Message Eviction")
+        tok = self._issue_token(c, "alice")
+        a = dict(self.args, approval_token=tok)
+        call_tool("run_playbook", a, c, _cfg(policy=True), actor_id="alice")
+        self.assertTrue(c.ran)
+
+    def test_invalid_token_does_not_execute(self):
+        c = _FakeClient("Containment")
+        a = dict(self.args, approval_token="approve_bogus")
+        out = call_tool("run_playbook", a, c, _cfg(policy=True), actor_id="alice")
+        self.assertIn("Invalid or expired", out)
+        self.assertFalse(c.ran)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change-Contract
- **Neu:** `policy/approvals.py` (ApprovalStore), `test_policy_approvals.py`
- **Edit:** `soar_mcp_tools.py` (`_policy_gate` Approval-Flow, `call_tool` +actor_id), `soar_mcp_handler.py` (actor_id durchreichen), `test_policy_gate.py`, `.gitignore` (local/)
- **Unangetastet:** Decision-Core (P1), ALLOW/DENY-Pfad, Playbook-Ausführung, alle anderen Tools

## Issue #138 (Phase 3/4 von #135)
Gehaltene 1CLICK/2PERSON-Runs sammeln jetzt Freigaben und führen dann aus. Identität = scoped-Token `soar_user_id`. **2-Personen** = zwei *verschiedene* soar_user_ids, **kein Self-Approval**. Store nach #50/#116/#127-Muster (file-backed, fcntl-locked, TTL, single-use). Jede Freigabe auditiert.

**Fail-safe:** ohne scoped-Token-Identität ⇒ HOLD (nie Ausführung); ungültiges/abgelaufenes Token ⇒ Neustart. `local/` jetzt gitignored.

## Verifikation (L6)
- Clean-Run `unittest discover`: **138 Tests, `OK`**, 0× FAILED/ERROR
- Neu: 9 Store-Units + 4 Gate-Flow-Tests (zwei verschiedene Approver → Ausführung; Self-Approval blockiert; 1-Click führt aus; ungültiges Token blockiert)

Teil 3/4 von #135. 🤖 Generated with [Claude Code](https://claude.com/claude-code)