### PR TITLE
feat(policy): policy_enabled as asset-config UI checkbox (#144)

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,9 @@ tail -f /var/log/phantom/soar/phantom.log | grep soar_mcp_handler
 
 ## Changelog
 
+### v1.12.1 (2026-07-16)
+- ✨ **#144** — the policy layer is now togglable from the **asset-config UI** (checkbox *policy_enabled*), no more hand-editing `local/mcp.conf`. Consistent with `enable_test_harness` / `scoped_tokens_enabled`: the connector persists the checkbox to `local/asset_overrides.json` and the handler applies it per request (UI value takes precedence over `mcp.conf`; unset ⇒ `mcp.conf` fallback). Default off (backwards-compatible).
+
 ### v1.12.0 (2026-07-15)
 - ✨ **#135 Policy layer (gated-autonomous `run_playbook`)** — an unbypassable SOC guard in `call_tool` (the single dispatch chokepoint), **opt-in** via `[policy] enabled` (default off, backwards-compatible). Every `run_playbook` is evaluated to one of **ALLOW / APPROVE_1CLICK / APPROVE_2PERSON / DENY** before dispatch. Category sets the base gate; risk can only escalate, never relax; unknown category ⇒ `default_gate` (fail-safe, never ALLOW). Data-driven `policy/policy_config.json` — categories are extensible without code changes.
   - **#136 (P1)** decision core + config + 12 unit tests.

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -465,6 +465,12 @@ class McpConfigLoader:
         if eth is not None:
             config.enable_test_harness = bool(eth)
 
+        # Apply policy_enabled override (#144). None = not set in asset config →
+        # keep the mcp.conf [policy] value. The UI checkbox takes precedence.
+        pol = overrides.get("policy_enabled")
+        if pol is not None:
+            config.policy_enabled = bool(pol)
+
         ssl_override = overrides.get("ssl_verify")
         if ssl_override is not None:
             if isinstance(ssl_override, bool):

--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -159,6 +159,11 @@ class SoarMcpConnector(BaseConnector):
         eth_val = asset_cfg.get("enable_test_harness")
         enable_test_harness = bool(eth_val) if eth_val is not None else None
 
+        # policy_enabled checkbox (#144) — None means "not set in asset config,
+        # fall back to mcp.conf [policy] value".
+        pol_val = asset_cfg.get("policy_enabled")
+        policy_enabled = bool(pol_val) if pol_val is not None else None
+
         ssl_val = asset_cfg.get("ssl_verify")
         ssl_verify = bool(ssl_val) if ssl_val is not None else None
 
@@ -177,6 +182,7 @@ class SoarMcpConnector(BaseConnector):
             "tools": tool_overrides,
             "ai_instructions": ai_instructions,
             "enable_test_harness": enable_test_harness,
+            "policy_enabled": policy_enabled,
             "ssl_verify": ssl_verify,
             "asset_name": self._asset_name,
             "base_url": self._base_url,

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -8,8 +8,8 @@
     "product_version_regex": ".*",
     "publisher": "Andreas Buis",
     "license": "Copyright 2026 Andreas Buis",
-    "app_version": "1.12.0",
-    "utctime_updated": "2026-07-15T12:00:00.000000Z",
+    "app_version": "1.12.1",
+    "utctime_updated": "2026-07-16T12:00:00.000000Z",
     "package_name": "phantom_soar_mcp_server",
     "main_module": "soar_mcp_connector.py",
     "min_phantom_version": "8.5.0",
@@ -194,6 +194,13 @@
             "default": false,
             "required": false,
             "order": 41
+        },
+        "policy_enabled": {
+            "description": "Policy layer (gated-autonomous run_playbook, issue #135). When enabled, every run_playbook is evaluated by an unbypassable SOC guard before dispatch (ALLOW / APPROVE_1CLICK / APPROVE_2PERSON / DENY): category sets the base gate, risk can only escalate, unknown category is held (never auto-run). 1-click/2-person runs collect distinct human approval(s) via scoped MCP tokens before executing. Category -> gate mapping is data-driven (policy/policy_config.json). Default off (backwards-compatible).",
+            "data_type": "boolean",
+            "default": false,
+            "required": false,
+            "order": 42
         },
         "tool_list_apps": {
             "description": "READ \u2014 list_apps: List installed SOAR apps/connectors (name, vendor, supported actions). Used by the playbook-builder skill for connector discovery.",

--- a/test_soar_mcp_config_asset_overrides.py
+++ b/test_soar_mcp_config_asset_overrides.py
@@ -26,6 +26,32 @@ class SoarMcpConfigAssetOverridesTest(unittest.TestCase):
 
         self.assertFalse(cfg.ssl_verify)
 
+    def _load_with(self, mcp_conf: str, overrides: dict | None):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "default").mkdir()
+            (root / "local").mkdir()
+            (root / "default" / "mcp.conf").write_text(mcp_conf, encoding="utf-8")
+            if overrides is not None:
+                (root / "local" / "asset_overrides.json").write_text(
+                    json.dumps(overrides), encoding="utf-8")
+            return McpConfigLoader(root).load()
+
+    def test_policy_enabled_override_true_beats_mcp_conf_false(self):
+        cfg = self._load_with("[policy]\nenabled = false\n", {"policy_enabled": True})
+        self.assertTrue(cfg.policy_enabled)   # UI checkbox wins (#144)
+
+    def test_policy_enabled_override_false_beats_mcp_conf_true(self):
+        cfg = self._load_with("[policy]\nenabled = true\n", {"policy_enabled": False})
+        self.assertFalse(cfg.policy_enabled)
+
+    def test_policy_enabled_absent_override_keeps_mcp_conf(self):
+        # None / key absent -> fall back to the mcp.conf [policy] value
+        cfg = self._load_with("[policy]\nenabled = true\n", {"ssl_verify": True})
+        self.assertTrue(cfg.policy_enabled)
+        cfg2 = self._load_with("[policy]\nenabled = true\n", {"policy_enabled": None})
+        self.assertTrue(cfg2.policy_enabled)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Change-Contract
- **Edit:** `soar_mcp_server.json` (configuration.policy_enabled), `soar_mcp_connector.py` (_write_asset_overrides), `soar_mcp_config.py` (_apply_asset_overrides)
- **Neu:** 3 Override-Tests in `test_soar_mcp_config_asset_overrides.py`
- **Unangetastet:** Gate-/Approval-Logik (P1–P3), Default OFF

## Issue #144
Policy-Schicht per **UI-Häkchen** schaltbar statt Handedit in `mcp.conf` — gleicher Override-Pfad wie `enable_test_harness`/`scoped_tokens_enabled`. UI hat Vorrang; unset ⇒ mcp.conf-Fallback.

## Verifikation (L6)
- Clean `unittest discover`: **141 Tests, `OK`** (3 neue Override-Tests: true>false, false>true, absent behält mcp.conf)
- Manifest-JSON valid

Release v1.12.1. 🤖 Generated with [Claude Code](https://claude.com/claude-code)