### PR TITLE
feat(policy): policy_enabled in diagnostics + ungated run_playbook flag (#151)

### DIFF
--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -283,6 +283,10 @@ def build_posture_report(config: "McpServerConfig") -> dict:
         risk_flags.append("scoped_tokens_without_fernet_encryption")
     if config.scoped_tokens_enabled and not config.scoped_tokens_required and enabled_write:
         risk_flags.append("legacy_full_tokens_still_accepted")
+    # run_playbook executes response actions; without the policy gate every run is
+    # autonomous. Flag ungated execution so the posture reflects it (#151).
+    if "run_playbook" in config.enabled_tools and not config.policy_enabled:
+        risk_flags.append("run_playbook_without_policy_gate")
 
     return {
         "write_tools_enabled": config.write_tools_enabled,
@@ -290,6 +294,7 @@ def build_posture_report(config: "McpServerConfig") -> dict:
         "ssl_verify": ssl,
         "enable_test_harness": config.enable_test_harness,
         "require_confirmation": config.require_confirmation,
+        "policy_enabled": config.policy_enabled,
         "scoped_tokens_enabled": config.scoped_tokens_enabled,
         "scoped_tokens_required": config.scoped_tokens_required,
         "fernet_available": fernet_available,

--- a/test_soar_mcp_confirm_and_harness.py
+++ b/test_soar_mcp_confirm_and_harness.py
@@ -79,6 +79,41 @@ class PostureRateLimitTest(unittest.TestCase):
         self.assertFalse(build_posture_report(cfg)["legacy_path_rate_limited"])
 
 
+class PolicyPostureVisibilityTest(unittest.TestCase):
+    """#151: posture surfaces policy_enabled and flags ungated run_playbook."""
+
+    def test_policy_enabled_is_reported(self):
+        from soar_mcp_config import build_posture_report
+        cfg = McpServerConfig()
+        self.assertIn("policy_enabled", build_posture_report(cfg))
+        cfg.policy_enabled = True
+        self.assertTrue(build_posture_report(cfg)["policy_enabled"])
+
+    def test_flag_set_when_run_playbook_enabled_without_policy(self):
+        from soar_mcp_config import build_posture_report
+        cfg = McpServerConfig()
+        cfg.enabled_tools = set(cfg.enabled_tools) | {"run_playbook"}
+        cfg.policy_enabled = False
+        self.assertIn("run_playbook_without_policy_gate",
+                      build_posture_report(cfg)["risk_flags"])
+
+    def test_flag_absent_when_policy_enabled(self):
+        from soar_mcp_config import build_posture_report
+        cfg = McpServerConfig()
+        cfg.enabled_tools = set(cfg.enabled_tools) | {"run_playbook"}
+        cfg.policy_enabled = True
+        self.assertNotIn("run_playbook_without_policy_gate",
+                         build_posture_report(cfg)["risk_flags"])
+
+    def test_flag_absent_when_run_playbook_disabled(self):
+        from soar_mcp_config import build_posture_report
+        cfg = McpServerConfig()
+        cfg.enabled_tools = {t for t in cfg.enabled_tools if t != "run_playbook"}
+        cfg.policy_enabled = False
+        self.assertNotIn("run_playbook_without_policy_gate",
+                         build_posture_report(cfg)["risk_flags"])
+
+
 class _FakeContainerClient:
     def __init__(self, label="events", name="mcp_write_suite_1", delete_err=None,
                  get_err=None):


### PR DESCRIPTION
## Change-Contract
- **Edit:** `soar_mcp_config.py` `build_posture_report()` — add `policy_enabled` field + `run_playbook_without_policy_gate` risk flag
- **Neu:** 4 Posture-Tests
- **Unangetastet:** diagnose-Tool (generisches Flag→Finding-Mapping), Policy-Logik

## Issue #151
`diagnose_soar_mcp_environment.security_posture` zeigt jetzt `policy_enabled`; ungated `run_playbook` (enabled, aber Policy aus) wird als Risk-Flag/Finding sichtbar. Rein additiv/advisory.

## Verifikation (L6)
- Clean `unittest discover`: **OK** (4 neue Tests: policy_enabled gemeldet; Flag an bei run_playbook+policy off; aus bei policy on; aus bei run_playbook disabled)

Part of v1.12.4. 🤖 Generated with [Claude Code](https://claude.com/claude-code)