### PR TITLE
feat(custom-functions): draft write with allowlist + revision gates (S2, #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Transform Splunk SOAR into an MCP (Model Context Protocol) server endpoint for d
 
 **Key Features:**
 - ✅ **100% On-Premises** — No cloud services, no data exfiltration
-- ✅ **Read-Only by Default** — 33 read tools active, 10 write tools opt-in via UI checkboxes (43 tools total)
+- ✅ **Read-Only by Default** — 33 read tools active, 12 write tools opt-in via UI checkboxes (45 tools total)
 - ✅ **Asset-Based Configuration** — Control all tool availability via SOAR UI checkboxes, no SSH required
 - ✅ **COA Visual Editor Stack** — Full playbook graph inspection, validation, diff, and import/export (v1.6.3+)
 - ✅ **AI Instructions Field** — Inject SOC-specific context into every AI session
@@ -26,7 +26,7 @@ Transform Splunk SOAR into an MCP (Model Context Protocol) server endpoint for d
 - **Fully on-premises** — the app itself adds no cloud dependency and performs no external data transfer
 
 ### The tool model
-- **43 tools total:** 33 read-only (enabled by default) + 10 write tools (opt-in per SOAR UI checkbox)
+- **45 tools total:** 33 read-only (enabled by default) + 12 write tools (opt-in per SOAR UI checkbox)
 - **Read:** inspect cases, artifacts, playbooks, and notes; inspect, validate, and diff the COA playbook graph
 - **Write (deliberately opt-in):** add notes, change case status/severity/owner, create artifacts, `run_playbook` (triggers real response actions), and `import_playbook`
 - Tool availability and all configuration are controlled entirely through **asset-config checkboxes** — no SSH required
@@ -587,6 +587,13 @@ tail -f /var/log/phantom/soar/phantom.log | grep soar_mcp_handler
 ---
 
 ## Changelog
+
+### v1.14.0 (2026-07-16)
+- ✨ **#159 Custom Functions — draft write (slice S2)** — two new WRITE tools (45 tools total: 33 read / 12 write, both **off by default**): `create_custom_function_draft` and `update_custom_function_draft`. They only ever write **drafts** — publishing is explicitly refused. Built on the facts the S1 probe measured, not on assumptions:
+  - **Repository allowlist** (`custom_function_write_scm_ids`, set in the **asset-config UI**): **empty by default = no write to any repository**. `scm_id` values are instance-specific — the probe found `local` = 2 while `community` (Splunk's own content) = 1, so no code default could be safe.
+  - **`is_read_only`** → refuse. **`draft_mode=false`** (publish) → refuse. **`commit_message`** required with source (API constraint). **`expected_revision`** must match the current `commit_sha` → else `REVISION_CONFLICT`, **no force update**. `name`/`scm_id` are never sent on update (immutable per API).
+  - **`dry_run=true` by default** — previews the payload (source shown as length + sha256, never echoed) and writes nothing. The #50 confirmation gate applies automatically.
+  - **No DELETE**: Splunk does not document the endpoint, so it is not built on an assumption.
 
 ### v1.13.1 (2026-07-16)
 - 🐛 **#157 Custom Function reads told the truth about what SOAR actually returned** — the S1 live probe (8.5.0.248) showed the read tools silently misreporting facts an AI agent would then build on. Fixed: (1) the list projection omits `scm_id`/`inputs`/`outputs`, so per-function counts are now **omitted rather than reported as `0`/`null`** ("not returned" ≠ "none") and the response says so (`LIST_PROJECTION_SPARSE`); (2) `warnings`/`errors` are only reported when SOAR actually returns them — this build omits them on GET, so defaulting to `[]` claimed "no warnings" (`VALIDATION_DETAIL_UNAVAILABLE`); (3) `passed_validation` is `false` for *every* function on this build (including Splunk's own), so the warning now only fires when warnings/errors corroborate it; (4) a truncated list (e.g. 50 of 157) is now disclosed with a `name=`/`scm_id=` tip.

--- a/default/mcp.conf
+++ b/default/mcp.conf
@@ -207,6 +207,17 @@ get_custom_function = true
 # Never write-probes; operations not positively observed report 'unknown'.
 detect_custom_function_capabilities = true
 
+# ── Custom Function DRAFT-WRITE tools (v1.14.0+ — OFF by default) ─────────────
+# These also require a non-empty [custom_functions] allowed_write_scm_ids, and
+# default to dry_run=true. They only ever write drafts — never publish.
+
+# Create a custom function as a draft. WRITE — off by default.
+create_custom_function_draft = false
+
+# Update an existing draft custom function (requires expected_revision).
+# WRITE — off by default.
+update_custom_function_draft = false
+
 # ── COA Write tool (experimental — disabled by default, requires endpoint verification) ──
 
 # Save node x/y positions only; dry_run=true (default) previews without writing.
@@ -314,6 +325,24 @@ default_lifetime_days = 90
 # rate_limit_per_minute * <worker_count>. Do not rely on this as a hard
 # DoS ceiling — use a reverse-proxy rate limit for that.
 rate_limit_per_minute = 120
+
+# ==============================================================================
+# [custom_functions] — Custom Function draft-write allowlist (issue #159).
+# ==============================================================================
+
+[custom_functions]
+# Comma-separated repository (scm_id) values that create/update_custom_function_draft
+# may write to. EMPTY = no write allowed at all (fail-safe default).
+#
+# Resolve the ids with detect_custom_function_capabilities — they are NOT stable
+# across instances. On the reference instance 'local' is scm_id 2 while scm_id 1 is
+# 'community' (Splunk's own content). Never grant a production or community repo.
+#
+# Prefer setting this in the asset configuration UI (field:
+# custom_function_write_scm_ids) — the UI value takes precedence over this file.
+# Example: allowed_write_scm_ids = 2
+allowed_write_scm_ids =
+
 
 # ==============================================================================
 # [policy] — Gated-autonomous run_playbook (issue #135). Opt-in.

--- a/soar_mcp_config.py
+++ b/soar_mcp_config.py
@@ -114,6 +114,10 @@ ALL_TOOLS: list[str] = [
     "list_custom_functions",
     "get_custom_function",
     "detect_custom_function_capabilities",
+    # Custom Function draft write (v1.14.0+, #159) — deliberately NOT in
+    # READ_ONLY_TOOLS: that is what makes them write tools (confirmation gate).
+    "create_custom_function_draft",
+    "update_custom_function_draft",
 ]
 
 READ_ONLY_TOOLS: frozenset[str] = frozenset(
@@ -206,6 +210,13 @@ class McpServerConfig:
     # every run_playbook is evaluated by the policy guard (ALLOW / APPROVE_1CLICK /
     # APPROVE_2PERSON / DENY) before dispatch. Default off = backwards-compatible.
     policy_enabled: bool = False
+
+    # Custom Function draft-write allowlist (#159). Repository (scm_id) values that
+    # create/update_custom_function_draft may write to. EMPTY = no write allowed at
+    # all — fail-safe by design: the S1 probe showed 'local' is scm_id 2 while
+    # 'community' (Splunk's own, read-only content) is 1, so a wrong default would
+    # silently target the wrong repository. Admins opt in per asset config.
+    custom_function_write_scm_ids: list[int] = field(default_factory=list)
 
     # AI instructions — sent to the LLM in every MCP initialize response
     ai_instructions: str = ""
@@ -395,6 +406,8 @@ class McpConfigLoader:
         config.enable_test_harness = self._get_bool(parser, "safety", "enable_test_harness", False)
         config.require_confirmation = self._get_bool(parser, "safety", "require_confirmation", False)
         config.policy_enabled = self._get_bool(parser, "policy", "enabled", False)
+        config.custom_function_write_scm_ids = self._parse_scm_ids(
+            parser.get("custom_functions", "allowed_write_scm_ids", fallback=""))
         config.test_container_label = (
             parser.get("safety", "test_container_label", fallback="test").strip() or "test")
         config.test_container_name_prefix = (
@@ -484,6 +497,12 @@ class McpConfigLoader:
         if pol is not None:
             config.policy_enabled = bool(pol)
 
+        # Custom Function write allowlist (#159). None = not set in the asset config
+        # -> keep the mcp.conf value. The UI field is the intended way to grant this.
+        cf_ids = overrides.get("custom_function_write_scm_ids")
+        if cf_ids is not None:
+            config.custom_function_write_scm_ids = self._parse_scm_ids(cf_ids)
+
         ssl_override = overrides.get("ssl_verify")
         if ssl_override is not None:
             if isinstance(ssl_override, bool):
@@ -499,6 +518,25 @@ class McpConfigLoader:
         return config
 
     # ── Helpers ────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _parse_scm_ids(raw: object) -> list[int]:
+        """Parse a comma-separated scm_id allowlist. Anything unparsable is dropped
+        (fail-safe: a malformed entry must never widen the allowlist)."""
+        ids: list[int] = []
+        for part in str(raw or "").split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                value = int(part)
+            except (TypeError, ValueError):
+                logger.warning("[MCP Config] Ignoring non-numeric scm_id in "
+                               "allowed_write_scm_ids: %r", part)
+                continue
+            if value > 0 and value not in ids:
+                ids.append(value)
+        return ids
 
     @staticmethod
     def _get_bool(parser: configparser.ConfigParser, section: str, key: str, default: bool) -> bool:

--- a/soar_mcp_connector.py
+++ b/soar_mcp_connector.py
@@ -164,6 +164,11 @@ class SoarMcpConnector(BaseConnector):
         pol_val = asset_cfg.get("policy_enabled")
         policy_enabled = bool(pol_val) if pol_val is not None else None
 
+        # Custom Function draft-write allowlist (#159). Empty string is meaningful
+        # ("explicitly no repositories"), so only None falls back to mcp.conf.
+        cf_ids_val = asset_cfg.get("custom_function_write_scm_ids")
+        cf_write_scm_ids = str(cf_ids_val).strip() if cf_ids_val is not None else None
+
         ssl_val = asset_cfg.get("ssl_verify")
         ssl_verify = bool(ssl_val) if ssl_val is not None else None
 
@@ -183,6 +188,7 @@ class SoarMcpConnector(BaseConnector):
             "ai_instructions": ai_instructions,
             "enable_test_harness": enable_test_harness,
             "policy_enabled": policy_enabled,
+            "custom_function_write_scm_ids": cf_write_scm_ids,
             "ssl_verify": ssl_verify,
             "asset_name": self._asset_name,
             "base_url": self._base_url,

--- a/soar_mcp_server.json
+++ b/soar_mcp_server.json
@@ -8,8 +8,8 @@
     "product_version_regex": ".*",
     "publisher": "Andreas Buis",
     "license": "Copyright 2026 Andreas Buis",
-    "app_version": "1.13.1",
-    "utctime_updated": "2026-07-16T21:00:00.000000Z",
+    "app_version": "1.14.0",
+    "utctime_updated": "2026-07-16T22:00:00.000000Z",
     "package_name": "phantom_soar_mcp_server",
     "main_module": "soar_mcp_connector.py",
     "min_phantom_version": "8.5.0",
@@ -215,6 +215,26 @@
             "default": true,
             "required": false,
             "order": 87
+        },
+        "tool_create_custom_function_draft": {
+            "description": "WRITE ⚠️ — create_custom_function_draft: Create a custom function as a DRAFT. Requires the target repository to be listed in custom_function_write_scm_ids. dry_run=true by default. Never publishes.",
+            "data_type": "boolean",
+            "default": false,
+            "required": false,
+            "order": 92
+        },
+        "tool_update_custom_function_draft": {
+            "description": "WRITE ⚠️ — update_custom_function_draft: Update an existing DRAFT custom function. Requires expected_revision (optimistic concurrency) and the repository allowlist. dry_run=true by default. Never publishes.",
+            "data_type": "boolean",
+            "default": false,
+            "required": false,
+            "order": 93
+        },
+        "custom_function_write_scm_ids": {
+            "description": "Custom Function write allowlist (issue #159) — comma-separated repository (scm_id) values that the draft-write tools may write to. EMPTY = no writes at all (fail-safe default). Resolve ids with detect_custom_function_capabilities; they are NOT stable across instances (on the reference instance 'local' is 2 and 'community' is 1). Never grant a community or production repository. Example: 2",
+            "data_type": "string",
+            "required": false,
+            "order": 94
         },
         "policy_enabled": {
             "description": "Policy layer (gated-autonomous run_playbook, issue #135). When enabled, every run_playbook is evaluated by an unbypassable SOC guard before dispatch (ALLOW / APPROVE_1CLICK / APPROVE_2PERSON / DENY): category sets the base gate, risk can only escalate, unknown category is held (never auto-run). 1-click/2-person runs collect distinct human approval(s) via scoped MCP tokens before executing. Category -> gate mapping is data-driven (policy/policy_config.json). Default off (backwards-compatible).",

--- a/soar_mcp_tools.py
+++ b/soar_mcp_tools.py
@@ -4590,6 +4590,220 @@ def tool_detect_custom_function_capabilities(
         findings=findings, fmt=fmt)
 
 
+def _cf_write_denied(config: McpServerConfig, scm_id, fmt: str) -> Optional[str]:
+    """Repository allowlist gate (#159). Returns an envelope string to abort, or None.
+
+    Fail-safe: an empty allowlist denies every write. The allowlist is an explicit
+    admin choice in the asset config — never a code default, because scm_id values
+    are instance-specific (scm_id 1 is Splunk's 'community' repo on the reference
+    instance, 'local' is 2).
+    """
+    from soar_mcp_envelope import envelope_response
+    allowed = list(getattr(config, "custom_function_write_scm_ids", []) or [])
+    if not allowed:
+        return envelope_response(
+            False,
+            "Blocked: custom function writes are not enabled for any repository.",
+            errors=[{"code": "WRITE_REPO_NOT_ALLOWED",
+                     "safe_message": "custom_function_write_scm_ids is empty. Set the allowed "
+                                     "repository ids in the asset configuration "
+                                     "(custom_function_write_scm_ids) and run Test Connectivity. "
+                                     "Resolve ids with detect_custom_function_capabilities."}],
+            fmt=fmt)
+    if scm_id not in allowed:
+        return envelope_response(
+            False, f"Blocked: repository scm_id={scm_id} is not in the write allowlist.",
+            errors=[{"code": "WRITE_REPO_NOT_ALLOWED",
+                     "safe_message": f"Allowed repository ids: {allowed}."}],
+            fmt=fmt)
+    return None
+
+
+def _cf_draft_mode_denied(args: dict, fmt: str) -> Optional[str]:
+    """Refuse any attempt to leave/disable draft mode. Publishing is out of scope."""
+    from soar_mcp_envelope import envelope_response
+    if "draft_mode" in args and not args.get("draft_mode"):
+        return envelope_response(
+            False, "Blocked: this tool only writes drafts.",
+            errors=[{"code": "PUBLISH_NOT_SUPPORTED",
+                     "safe_message": "draft_mode=false would publish the function (and delete "
+                                     "the draft copy). Publishing is not supported by this tool."}],
+            fmt=fmt)
+    return None
+
+
+def _cf_build_payload(args: dict, *, include_identity: bool) -> tuple[dict, Optional[str]]:
+    """Build the REST body. Returns (payload, error_message)."""
+    source = args.get("source")
+    commit_message = (args.get("commit_message") or "").strip()
+    if source is not None and not commit_message:
+        # API constraint: commit_message is mandatory whenever `python` is sent.
+        return {}, "commit_message is required when source is provided."
+
+    payload: dict = {"draft_mode": True}   # always a draft — never publish
+    if include_identity:
+        payload["name"] = (args.get("name") or "").strip()
+        payload["scm_id"] = args.get("scm_id")
+    if args.get("description") is not None:
+        payload["description"] = args["description"]
+    if source is not None:
+        payload["python"] = source
+        payload["commit_message"] = commit_message
+    for spec in ("inputs", "outputs"):
+        if args.get(spec) is not None:
+            payload[spec] = args[spec]
+    return payload, None
+
+
+def tool_create_custom_function_draft(
+    client: SoarApiClient, config: McpServerConfig, args: dict
+) -> str:
+    """Create a custom function as a draft (WRITE, #159)."""
+    from soar_mcp_envelope import envelope_response, normalize_output_format
+    fmt = normalize_output_format(args.get("output_format"))
+
+    name = (args.get("name") or "").strip()
+    if not name:
+        return envelope_response(False, "name is required.",
+                                 errors=[{"code": "BAD_INPUT", "safe_message": "name is required"}],
+                                 fmt=fmt)
+    scm_id, err_msg = _require_positive_int(args.get("scm_id"), "scm_id")
+    if err_msg:
+        return envelope_response(False, err_msg,
+                                 errors=[{"code": "BAD_INPUT", "safe_message": err_msg}], fmt=fmt)
+
+    blocked = _cf_draft_mode_denied(args, fmt) or _cf_write_denied(config, scm_id, fmt)
+    if blocked:
+        return blocked
+
+    payload, perr = _cf_build_payload(args, include_identity=True)
+    if perr:
+        return envelope_response(False, perr,
+                                 errors=[{"code": "BAD_INPUT", "safe_message": perr}], fmt=fmt)
+
+    if args.get("dry_run", True):
+        return envelope_response(
+            True, f"Dry run — would create draft '{name}' in scm_id={scm_id}. Nothing was written.",
+            data={"dry_run": True, "method": "POST", "endpoint": "rest/custom_function",
+                  "payload_preview": _cf_preview_payload(payload)},
+            findings=[{"severity": "info", "code": "DRY_RUN",
+                       "message": "Re-run with dry_run=false to actually create the draft."}],
+            fmt=fmt)
+
+    data, err = client.post("custom_function", payload)
+    if err:
+        return envelope_response(False, f"Could not create draft '{name}': {err}",
+                                 errors=[{"code": "CF_CREATE_FAILED", "safe_message": str(err)}],
+                                 fmt=fmt)
+    return envelope_response(
+        True, f"Draft custom function '{name}' created in scm_id={scm_id}.",
+        data={"dry_run": False, "response": _cf_redact_response(data)},
+        findings=[{"severity": "info", "code": "DRAFT_SEMANTICS_OBSERVED",
+                   "message": "Raw (redacted) response returned so draft identity/semantics can "
+                              "be verified against this build."}],
+        fmt=fmt)
+
+
+def tool_update_custom_function_draft(
+    client: SoarApiClient, config: McpServerConfig, args: dict
+) -> str:
+    """Update an existing draft custom function (WRITE, #159)."""
+    from soar_mcp_envelope import envelope_response, normalize_output_format
+    fmt = normalize_output_format(args.get("output_format"))
+
+    cf_id, err_msg = _require_positive_int(args.get("custom_function_id"), "custom_function_id")
+    if err_msg:
+        return envelope_response(False, err_msg,
+                                 errors=[{"code": "BAD_INPUT", "safe_message": err_msg}], fmt=fmt)
+    expected_revision = (args.get("expected_revision") or "").strip()
+    if not expected_revision:
+        return envelope_response(
+            False, "expected_revision is required.",
+            errors=[{"code": "BAD_INPUT",
+                     "safe_message": "Read the current revision with get_custom_function and pass "
+                                     "it as expected_revision (optimistic concurrency)."}], fmt=fmt)
+
+    blocked = _cf_draft_mode_denied(args, fmt)
+    if blocked:
+        return blocked
+
+    # Pre-check against the live object: repo, read-only, revision, draft state.
+    current, err = client.get(f"custom_function/{cf_id}")
+    if err or not isinstance(current, dict):
+        return envelope_response(
+            False, f"Could not read custom function {cf_id}: {err or 'unexpected response'}",
+            errors=[{"code": "CF_READ_FAILED", "safe_message": str(err or "unexpected response")}],
+            fmt=fmt)
+
+    blocked = _cf_write_denied(config, current.get("scm_id"), fmt)
+    if blocked:
+        return blocked
+
+    if current.get("is_read_only"):
+        return envelope_response(
+            False, f"Blocked: custom function {cf_id} is read-only.",
+            errors=[{"code": "CF_READ_ONLY",
+                     "safe_message": "SOAR reports is_read_only=true for this function."}], fmt=fmt)
+
+    actual_revision = current.get("commit_sha")
+    if actual_revision != expected_revision:
+        return envelope_response(
+            False, "Blocked: the draft changed since it was read.",
+            errors=[{"code": "REVISION_CONFLICT",
+                     "safe_message": "expected_revision does not match the current revision. "
+                                     "Re-read with get_custom_function and retry; there is no "
+                                     "force update."}], fmt=fmt)
+
+    payload, perr = _cf_build_payload(args, include_identity=False)  # name/scm_id are immutable
+    if perr:
+        return envelope_response(False, perr,
+                                 errors=[{"code": "BAD_INPUT", "safe_message": perr}], fmt=fmt)
+
+    findings: list = []
+    if not current.get("draft_mode"):
+        findings.append({
+            "severity": "warn", "code": "TARGET_WAS_NOT_A_DRAFT",
+            "message": "The target is currently not in draft mode; this write sets draft_mode=true.",
+        })
+
+    if args.get("dry_run", True):
+        return envelope_response(
+            True, f"Dry run — would update draft {cf_id}. Nothing was written.",
+            data={"dry_run": True, "method": "POST", "endpoint": f"rest/custom_function/{cf_id}",
+                  "payload_preview": _cf_preview_payload(payload)},
+            findings=findings + [{"severity": "info", "code": "DRY_RUN",
+                                  "message": "Re-run with dry_run=false to apply the update."}],
+            fmt=fmt)
+
+    data, err = client.post(f"custom_function/{cf_id}", payload)
+    if err:
+        return envelope_response(False, f"Could not update draft {cf_id}: {err}",
+                                 errors=[{"code": "CF_UPDATE_FAILED", "safe_message": str(err)}],
+                                 fmt=fmt)
+    return envelope_response(True, f"Draft custom function {cf_id} updated.",
+                             data={"dry_run": False, "response": _cf_redact_response(data)},
+                             findings=findings, fmt=fmt)
+
+
+def _cf_preview_payload(payload: dict) -> dict:
+    """Payload preview for dry runs — source is summarised, never echoed in full."""
+    preview = {k: v for k, v in payload.items() if k != "python"}
+    src = payload.get("python")
+    if isinstance(src, str):
+        preview["python"] = f"<{len(src)} chars, sha256={hashlib.sha256(src.encode()).hexdigest()}>"
+    return preview
+
+
+def _cf_redact_response(data) -> dict:
+    """Return the write response without echoing the full source back."""
+    if not isinstance(data, dict):
+        return {"raw_type": type(data).__name__}
+    out = {k: v for k, v in data.items() if k != "python"}
+    if isinstance(data.get("python"), str):
+        out["python"] = f"<{len(data['python'])} chars>"
+    return out
+
+
 TOOL_SCHEMAS["list_custom_functions"] = {
     "description": (
         "READ — List Splunk SOAR custom functions with id, name, draft_mode, "
@@ -4633,6 +4847,72 @@ TOOL_SCHEMAS["get_custom_function"] = {
             "output_format": {"type": "string", "enum": ["text", "json"], "default": "text"},
         },
         "required": ["custom_function_id"],
+    },
+}
+
+_CF_IO_SCHEMA = {
+    "type": "array",
+    "description": "Optional. inputs entries: {name, description, contains_type[], "
+                   "input_type: item|list}. outputs entries: {data_path, description, "
+                   "contains_type[]}.",
+    "items": {"type": "object"},
+}
+
+TOOL_SCHEMAS["create_custom_function_draft"] = {
+    "description": (
+        "⚠️ WRITE — Create a custom function as a DRAFT (never publishes). The target "
+        "repository must be in the asset-config allowlist (custom_function_write_scm_ids); "
+        "an empty allowlist blocks every write. dry_run=true by default: the first call "
+        "previews the payload and writes nothing. Resolve scm_id with "
+        "detect_custom_function_capabilities — ids are instance-specific."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string", "description": "Function name (immutable afterwards)."},
+            "scm_id": {"type": "integer",
+                       "description": "Target repository id. Must be in the write allowlist."},
+            "source": {"type": "string", "description": "Python source for the function."},
+            "commit_message": {"type": "string",
+                               "description": "Required whenever source is provided."},
+            "description": {"type": "string"},
+            "inputs": _CF_IO_SCHEMA,
+            "outputs": _CF_IO_SCHEMA,
+            "dry_run": {"type": "boolean",
+                        "description": "Preview without writing (default: true).",
+                        "default": True},
+        },
+        "required": ["name", "scm_id"],
+    },
+}
+
+TOOL_SCHEMAS["update_custom_function_draft"] = {
+    "description": (
+        "⚠️ WRITE — Update an existing DRAFT custom function (never publishes). Requires "
+        "expected_revision from get_custom_function: if the draft changed since you read it "
+        "the write is refused with REVISION_CONFLICT (no force update). Refuses read-only "
+        "functions and repositories outside the allowlist. dry_run=true by default. "
+        "name/scm_id are immutable and are never sent."
+    ),
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "custom_function_id": {"type": "integer"},
+            "expected_revision": {
+                "type": "string",
+                "description": "The 'revision' (commit_sha) from get_custom_function.",
+            },
+            "source": {"type": "string"},
+            "commit_message": {"type": "string",
+                               "description": "Required whenever source is provided."},
+            "description": {"type": "string"},
+            "inputs": _CF_IO_SCHEMA,
+            "outputs": _CF_IO_SCHEMA,
+            "dry_run": {"type": "boolean",
+                        "description": "Preview without writing (default: true).",
+                        "default": True},
+        },
+        "required": ["custom_function_id", "expected_revision"],
     },
 }
 
@@ -4703,6 +4983,10 @@ _TOOL_HANDLERS = {
     "list_custom_functions": tool_list_custom_functions,
     "get_custom_function": tool_get_custom_function,
     "detect_custom_function_capabilities": tool_detect_custom_function_capabilities,
+    # Custom Function draft write (#159) — NOT in READ_ONLY_TOOLS, so _WRITE_TOOLS
+    # picks them up automatically and the #50 confirmation gate applies.
+    "create_custom_function_draft": tool_create_custom_function_draft,
+    "update_custom_function_draft": tool_update_custom_function_draft,
     # Capability detection (v1.10.0+)
     "detect_soar_capabilities": tool_detect_soar_capabilities,
     # Visual playbook pre-edit audit (v1.11.0+)

--- a/test_custom_functions.py
+++ b/test_custom_functions.py
@@ -6,6 +6,8 @@ import unittest
 
 from soar_mcp_config import ALL_TOOLS, READ_ONLY_TOOLS, McpServerConfig
 from soar_mcp_tools import (
+    tool_create_custom_function_draft,
+    tool_update_custom_function_draft,
     TOOL_SCHEMAS,
     _TOOL_HANDLERS,
     tool_detect_custom_function_capabilities,
@@ -49,7 +51,10 @@ class _FakeClient:
         self._detail = detail
         self._list_err = list_err
         self._detail_err = detail_err
-        self._scm = scm if scm is not None else [{"id": 1, "name": "local"}]
+        # Real mapping on the reference instance: community=1, local=2 (#157) —
+        # do not encode the 'local == 1' assumption the source spec got wrong.
+        self._scm = scm if scm is not None else [{"id": 1, "name": "community"},
+                                                 {"id": 2, "name": "local"}]
         self._scm_err = scm_err
         self.last_params = None
 
@@ -233,7 +238,8 @@ class CapabilityProbeTest(unittest.TestCase):
         for op in ("create_draft", "update_draft", "delete_draft", "publish",
                    "runtime_test", "direct_result_read", "export"):
             self.assertEqual(caps[op], "unknown", op)
-        self.assertEqual(env["data"]["repositories"], [{"id": 1, "name": "local"}])
+        self.assertEqual(env["data"]["repositories"],
+                         [{"id": 1, "name": "community"}, {"id": 2, "name": "local"}])
 
     def test_probe_never_write_probes(self):
         calls = []
@@ -258,6 +264,151 @@ class CapabilityProbeTest(unittest.TestCase):
         self.assertFalse(env["ok"])
         self.assertEqual(env["data"]["capabilities"]["list"], "unsupported")
         self.assertIn("CF_LIST_FAILED", [f["code"] for f in env["findings"]])
+
+
+class _WriteClient(_FakeClient):
+    """Records writes so tests can prove a blocked path never wrote."""
+    def __init__(self, detail=None, **kw):
+        super().__init__(detail=detail, **kw)
+        self.posts = []
+
+    def post(self, path, body):
+        self.posts.append((path, body))
+        return {"id": 99, "name": "new_fn", "draft_mode": True, "commit_sha": "abc"}, None
+
+
+def _wcfg(allow=(2,)):
+    c = McpServerConfig()
+    c.custom_function_write_scm_ids = list(allow)
+    return c
+
+
+class DraftWriteRegistrationTest(unittest.TestCase):
+    def test_write_tools_are_write_not_read_only(self):
+        from soar_mcp_tools import _WRITE_TOOLS
+        for t in ("create_custom_function_draft", "update_custom_function_draft"):
+            self.assertIn(t, ALL_TOOLS, t)
+            self.assertNotIn(t, READ_ONLY_TOOLS, t)
+            self.assertIn(t, _WRITE_TOOLS, t)      # -> #50 confirmation gate applies
+            self.assertIn(t, TOOL_SCHEMAS, t)
+            self.assertIn(t, _TOOL_HANDLERS, t)
+
+
+class CreateDraftGateTest(unittest.TestCase):
+    def _create(self, cfg, **over):
+        args = {"name": "fn", "scm_id": 2, "source": "def fn(): pass",
+                "commit_message": "msg", "dry_run": False, "output_format": "json"}
+        args.update(over)
+        c = _WriteClient()
+        return c, _json(tool_create_custom_function_draft(c, cfg, args))
+
+    def test_empty_allowlist_blocks_every_write(self):
+        c, env = self._create(_wcfg(allow=()))
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "WRITE_REPO_NOT_ALLOWED")
+        self.assertEqual(c.posts, [])           # nothing written
+
+    def test_repo_outside_allowlist_blocks(self):
+        c, env = self._create(_wcfg(allow=(2,)), scm_id=1)   # 1 = community
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "WRITE_REPO_NOT_ALLOWED")
+        self.assertEqual(c.posts, [])
+
+    def test_publish_attempt_blocked(self):
+        c, env = self._create(_wcfg(), draft_mode=False)
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "PUBLISH_NOT_SUPPORTED")
+        self.assertEqual(c.posts, [])
+
+    def test_source_without_commit_message_blocked(self):
+        c, env = self._create(_wcfg(), commit_message="")
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "BAD_INPUT")
+        self.assertEqual(c.posts, [])
+
+    def test_dry_run_is_default_and_writes_nothing(self):
+        c = _WriteClient()
+        env = _json(tool_create_custom_function_draft(
+            c, _wcfg(), {"name": "fn", "scm_id": 2, "source": "def fn(): pass",
+                         "commit_message": "m", "output_format": "json"}))
+        self.assertTrue(env["ok"])
+        self.assertTrue(env["data"]["dry_run"])
+        self.assertEqual(c.posts, [])
+        # preview never echoes the full source back
+        self.assertIn("sha256=", env["data"]["payload_preview"]["python"])
+
+    def test_real_create_forces_draft_mode(self):
+        c, env = self._create(_wcfg())
+        self.assertTrue(env["ok"])
+        path, body = c.posts[0]
+        self.assertEqual(path, "custom_function")
+        self.assertIs(body["draft_mode"], True)          # always a draft
+        self.assertEqual(body["scm_id"], 2)
+        self.assertEqual(body["commit_message"], "msg")
+
+
+class UpdateDraftGateTest(unittest.TestCase):
+    def _update(self, cfg, detail=None, **over):
+        args = {"custom_function_id": 1, "expected_revision": "7e08d23",
+                "source": "def fn(): pass", "commit_message": "m",
+                "dry_run": False, "output_format": "json"}
+        args.update(over)
+        d = detail if detail is not None else _cf(draft=True)
+        c = _WriteClient(detail=d)
+        return c, _json(tool_update_custom_function_draft(c, cfg, args))
+
+    def test_revision_conflict_blocks_without_force(self):
+        c, env = self._update(_wcfg(), expected_revision="stale")
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "REVISION_CONFLICT")
+        self.assertEqual(c.posts, [])
+
+    def test_read_only_function_blocks(self):
+        d = _cf(draft=True)
+        d["is_read_only"] = True
+        c, env = self._update(_wcfg(), detail=d)
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "CF_READ_ONLY")
+        self.assertEqual(c.posts, [])
+
+    def test_repo_outside_allowlist_blocks(self):
+        d = _cf(draft=True)
+        d["scm_id"] = 1                      # community
+        c, env = self._update(_wcfg(allow=(2,)), detail=d)
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "WRITE_REPO_NOT_ALLOWED")
+        self.assertEqual(c.posts, [])
+
+    def test_missing_expected_revision_blocks(self):
+        c, env = self._update(_wcfg(), expected_revision="")
+        self.assertFalse(env["ok"])
+        self.assertEqual(env["errors"][0]["code"], "BAD_INPUT")
+        self.assertEqual(c.posts, [])
+
+    def test_update_never_sends_immutable_identity(self):
+        c, env = self._update(_wcfg())
+        self.assertTrue(env["ok"])
+        path, body = c.posts[0]
+        self.assertEqual(path, "custom_function/1")
+        self.assertNotIn("name", body)       # immutable per API
+        self.assertNotIn("scm_id", body)
+        self.assertIs(body["draft_mode"], True)
+
+    def test_non_draft_target_warns(self):
+        c, env = self._update(_wcfg(), detail=_cf(draft=False))
+        self.assertTrue(env["ok"])
+        self.assertIn("TARGET_WAS_NOT_A_DRAFT", [f["code"] for f in env["findings"]])
+
+
+class ScmIdAllowlistParseTest(unittest.TestCase):
+    def test_parse_is_fail_safe(self):
+        from soar_mcp_config import McpConfigLoader
+        p = McpConfigLoader._parse_scm_ids
+        self.assertEqual(p("2"), [2])
+        self.assertEqual(p(" 2 , 4 ,2"), [2, 4])        # trimmed + deduped
+        self.assertEqual(p(""), [])                      # empty -> no writes
+        self.assertEqual(p(None), [])
+        self.assertEqual(p("2,abc,-1,0"), [2])           # junk never widens the allowlist
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change-Contract (S2 — erster schreibender Slice)
- **Edit:** `soar_mcp_tools.py` (2 WRITE-Tools + Gates + Schemas + Handler), `soar_mcp_config.py` (`custom_function_write_scm_ids` + `_parse_scm_ids` + Asset-Override), `soar_mcp_connector.py` (UI-Wert persistieren), `soar_mcp_server.json` (2 Write-Checkboxen default **false** + UI-Feld), `default/mcp.conf` (`[custom_functions]`), `README.md`
- **Neu:** 14 Tests (jeder Block-Pfad)
- **Unangetastet:** kein DELETE, kein Publish, kein Rollback, keine Policy-Aenderung, keine HTTP-Client-Aenderung (Update = POST)

## Issue #159 — gebaut auf gemessenen Fakten, nicht auf den Specs

| Gate | Regel | Test |
|---|---|---|
| Repo-Allowlist | `custom_function_write_scm_ids` — **leer = kein Write ueberhaupt** | leer ⇒ block; fremdes scm_id ⇒ block |
| `is_read_only` | true ⇒ Ablehnung | block, kein POST |
| `draft_mode=false` | = Publish ⇒ Ablehnung | `PUBLISH_NOT_SUPPORTED` |
| `expected_revision` | != `commit_sha` ⇒ `REVISION_CONFLICT`, **kein Force** | block, kein POST |
| `commit_message` | Pflicht mit `source` (API-Zwang) | block |
| `dry_run` | **default true** — Preview, kein Write | `posts == []` |
| Confirm-Gate (#50) | automatisch (`_WRITE_TOOLS` = Handler − READ_ONLY) | Registrierungstest |

**Warum die Allowlist leer startet:** Die S1-Probe hat gemessen, dass `local` = **scm_id 2** ist und **`community` = 1**. Eine der Quell-Specs hatte `scm_id: 1` hartkodiert — das haette in Splunks community-Repo geschrieben. Es kann keinen sicheren Code-Default geben; der Admin traegt die Repos sichtbar im **Asset-Config-UI** ein (`custom_function_write_scm_ids`), wie bei `policy_enabled` (#144).

**Weitere Haerte:** `_parse_scm_ids` verwirft Unparsbares (`"2,abc,-1,0"` → `[2]`) — ein Tippfehler darf die Allowlist nie *aufweiten*. Source wird nie zurueckgespiegelt (Preview = Laenge + sha256; Write-Response redigiert).

**Kein DELETE:** Splunk dokumentiert den Endpunkt nicht. Wird nicht auf Verdacht gebaut.

## Offen (wird gemessen, nicht angenommen)
Draft-Semantik ist unbewiesen — es existiert **kein einziger Draft** auf der Instanz. Der erste echte Create gibt die (redigierte) Response zurueck (`DRAFT_SEMANTICS_OBSERVED`), damit wir sie belegen koennen.

## Verifikation (L6)
- Clean `unittest discover`: **203 Tests, `OK`**
- 45 Tools: 33 read / **12 write** — die zwei neuen sind korrekt als Write klassifiziert (`_WRITE_TOOLS`-Test)
- Manifest-JSON valid · `[custom_functions] allowed_write_scm_ids` parst leer

Release v1.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
